### PR TITLE
Fix level sounds continuing after quiting level

### DIFF
--- a/src/gmplay.nut
+++ b/src/gmplay.nut
@@ -394,7 +394,10 @@
 	}
 	drawDebug()
 
-	if(getcon("escape", "press")) startOverworld(game.world)
+	if(getcon("escape", "press")) {
+		startOverworld(game.world)
+		stopSound(-1)
+	}
 }
 
 ::playerTeleport <- function(_x, _y) { //Used to move the player and camera at the same time


### PR DESCRIPTION
A quick fix for a little issue, where sounds from levels continue even after the user quits the level with Escape. All sounds are now stopped when a level is exited.