### PR TITLE
Allow toggling both in-game timers

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -16,7 +16,12 @@
 		"language" : "Language",
 		"keyboard" : "Keyboard Controls",
 		"joystick" : "Gamepad Controls",
-		"speedrun" : "Speedrun Timer"
+		"timers" : "Speedrun Timers"
+	},
+
+	"timers-menu" : {
+		"speedrun-timer-level" : "Level Speedrun Timer",
+		"speedrun-timer-global" : "Global Speedrun Timer"
 	},
 
 	"bool" : {

--- a/src/global.nut
+++ b/src/global.nut
@@ -87,7 +87,8 @@
 	}
 	playerchar = 0
 	lang = "en"
-	showigt = false
+	showleveligt = false
+	showglobaligt = false
 }
 
 ::gvScreen <- 0

--- a/src/gmplay.nut
+++ b/src/gmplay.nut
@@ -501,8 +501,8 @@
 				break
 		}
 
-		//Draw IGT
-		if(gvDoIGT) drawText(font2, 8, 32, formatTime(gvIGT))
+		//Draw level IGT
+		if(gvDoIGT && config.showleveligt) drawText(font2, 8, 32, formatTime(gvIGT))
 
 		//Draw offscreen player
 		if(gvPlayer) if(gvPlayer.y < -8) {
@@ -533,7 +533,9 @@
 
 	if(levelEndRunner == 0) gvIGT++
 	game.igt++
-	if(config.showigt) {
+
+	//Draw global IGT
+	if(config.showglobaligt) {
 		local gtd = formatTime(game.igt) //Game time to draw
 		drawText(font2, (screenW() / 2) - (gtd.len() * 4), screenH() - 24, gtd)
 	}

--- a/src/menus.nut
+++ b/src/menus.nut
@@ -129,12 +129,27 @@ const fontH = 14
 		func = function() { selectLanguage() }
 	},
 	{
-		name = function() { return gvLangObj["options-menu"]["speedrun"] + ": " + (config.showigt ? gvLangObj["bool"]["on"] : gvLangObj["bool"]["off"]) },
-		func = function() { config.showigt = !config.showigt}
+		name = function() { return gvLangObj["options-menu"]["timers"] },
+		func = function() { cursor = 0; menu = meTimers }
 	},
 	{
 		name = function() { return "Back" },
 		func = function() { cursor = 0; menu = meMain; fileWrite("config.json", jsonWrite(config)) }
+	}
+]
+
+::meTimers <- [
+	{
+		name = function() { return gvLangObj["timers-menu"]["speedrun-timer-level"] + ": " + (config.showleveligt ? gvLangObj["bool"]["on"] : gvLangObj["bool"]["off"]) },	
+		func = function() { config.showleveligt = !config.showleveligt }
+	},
+	{
+		name = function() { return gvLangObj["timers-menu"]["speedrun-timer-global"] + ": " + (config.showglobaligt ? gvLangObj["bool"]["on"] : gvLangObj["bool"]["off"]) },	
+		func = function() { config.showglobaligt = !config.showglobaligt }
+	},
+	{
+		name = function() { return "Back" },
+		func = function() { cursor = 0; menu = meOptions }
 	}
 ]
 

--- a/src/overworld.nut
+++ b/src/overworld.nut
@@ -441,7 +441,7 @@
 	drawDebug()
 
 	game.igt++
-	if(config.showigt) {
+	if(config.showglobaligt) {
 		local gtd = formatTime(game.igt) //Game time to draw
 		drawText(font2, (screenW() / 2) - (gtd.len() * 4), screenH() - 24, gtd)
 	}


### PR DESCRIPTION
Allows both in-game timers (the global and the level one) to be toggled. Players are able to hide them, if they want to play casually, and vice versa. By default, both timers are off, but this can be changed.