### PR TITLE
Add cancel button to save overwriting menu

### DIFF
--- a/src/menus.nut
+++ b/src/menus.nut
@@ -228,6 +228,10 @@ const fontH = 14
 	{
 		name = function() { return "Yes" }
 		func = function() { newGame(game.file) }
+	},
+	{
+		name = function() { return "Cancel" }
+		func = function() { cursor = 0; menu = meNewGame }
 	}
 ]
 


### PR DESCRIPTION
Fixes an issue, where pressing the Pause key in the save overwriting menu will choose "Yes" and overwrite a save file, because of a "Cancel" button missing. This PR adds it.