### PR TITLE
Various menu improvements and fixes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -31,6 +31,7 @@
 
 	"controls-menu" : {
 		"press-key-for" : "Press key for",
+		"press-button-for" : "Press button for",
 		"up" : "up",
 		"down" : "down",
 		"left" : "left",

--- a/src/contriblevels.nut
+++ b/src/contriblevels.nut
@@ -66,8 +66,8 @@
 	meContribLevels.push(
 		{
 			name = function() { return gvLangObj["menu-commons"]["back"] }
-			func = function(){ menu = meMain }
-			back = function(){ menu = meMain }
+			func = function() { menu = meMain; cursor = 2 }
+			back = function() { menu = meMain; cursor = 2 }
 		}
 	)
 

--- a/src/controls.nut
+++ b/src/controls.nut
@@ -166,6 +166,7 @@
 					config.key.accept = anyKeyPress()
 					keystep++
 				}
+				break
 			default:
 				done = true
 				break
@@ -191,52 +192,53 @@
 	while(!done) {
 		drawBG()
 
-		local message = "Press button for "
+		local message = gvLangObj["controls-menu"]["press-button-for"] + " "
 		switch(joystep) {
 			case 4:
-				message += "jump"
+				message += gvLangObj["controls-menu"]["jump"]
 				if(anyJoyPress(0) != -1) {
 					config.joy.jump = anyJoyPress(0)
 					joystep++
 				}
+				if(getcon("pause", "press")) done = true;
 				break
 			case 5:
-				message += "shoot"
+				message += gvLangObj["controls-menu"]["shoot"]
 				if(anyJoyPress(0) != -1) {
 					config.joy.shoot = anyJoyPress(0)
 					joystep++
 				}
 				break
 			case 6:
-				message += "run"
+				message += gvLangObj["controls-menu"]["run"]
 				if(anyJoyPress(0) != -1) {
 					config.joy.run = anyJoyPress(0)
 					joystep++
 				}
 				break
 			case 7:
-				message += "sneak"
+				message += gvLangObj["controls-menu"]["sneak"]
 				if(anyJoyPress(0) != -1) {
 					config.joy.sneak = anyJoyPress(0)
 					joystep++
 				}
 				break
 			case 8:
-				message += "pause"
+				message += gvLangObj["controls-menu"]["pause"]
 				if(anyJoyPress(0) != -1) {
 					config.joy.pause = anyJoyPress(0)
 					joystep++
 				}
 				break
 			case 9:
-				message += "item swap"
+				message += gvLangObj["controls-menu"]["item-swap"]
 				if(anyJoyPress(0) != -1) {
 					config.joy.swap = anyJoyPress(0)
 					joystep++
 				}
 				break
 			case 10:
-				message += "manu accept"
+				message += gvLangObj["controls-menu"]["menu-accept"]
 				if(anyJoyPress(0) != -1) {
 					config.joy.accept = anyJoyPress(0)
 					joystep++

--- a/src/credits.nut
+++ b/src/credits.nut
@@ -43,7 +43,8 @@
 				break
 		}
 	}
-	creditsOffset += getcon("jump","hold")?2:0.5
+	creditsOffset += getcon("jump", "hold") || getcon("down", "hold") || getcon("accept", "hold") ? 2 : 0.5
+	creditsOffset -= getcon("up", "hold") && creditsOffset >= -10 ? 2 : 0
 	if(creditsOffset>=screenH()+creditsLength+10 || getcon("pause","press")){
 		for(local i=0; i<creditsSprites.len(); i+=1){
 			if(creditsSprites[i]==null)

--- a/src/languagemenu.nut
+++ b/src/languagemenu.nut
@@ -25,8 +25,8 @@
 		{
 			languageIndex = languageList["languages"].len()
 			name = function() { return gvLangObj["menu-commons"]["back"] }
-			func = function() { cursor = 0; menu = meOptions }
-			back = function() { cursor = 0; menu = meOptions }
+			func = function() { cursor = 2; menu = meOptions }
+			back = function() { cursor = 2; menu = meOptions }
 		}
 	)
 	menu = meLanguage

--- a/src/menus.nut
+++ b/src/menus.nut
@@ -51,7 +51,7 @@ const fontH = 14
 		menu[cursor].func()
 	}
 
-	if(getcon("pause", "press") && !(menu == mePausePlay || menu == mePauseOver || menu == meMain)) {
+	if(getcon("pause", "press")) {
 		for(local i = 0; i < menu.len(); i++) {
 				if(menu[i].rawin("back")) {
 					menu[i]["back"]()
@@ -80,14 +80,13 @@ const fontH = 14
 		name = function() { return gvLangObj["main-menu"]["options"] },
 		func = function() { cursor = 0; menu = meOptions }
 	},
-    {
-        name = function() { return gvLangObj["main-menu"]["credits"] },
-        func = function() { cursor = 0; startCredits(); }
-    }
+    	{
+		name = function() { return gvLangObj["main-menu"]["credits"] },
+		func = function() { cursor = 0; startCredits(); }
+    	}	
 	{
 		name = function() { return gvLangObj["main-menu"]["quit"] },
 		func = function() { gvQuit = 1 }
-		back = function() { gvQuit = 1 }
 	}
 ]
 
@@ -144,8 +143,8 @@ const fontH = 14
 	},
 	{
 		name = function() { return gvLangObj["menu-commons"]["back"] },
-		func = function() { cursor = 0; menu = meMain; fileWrite("config.json", jsonWrite(config)) }
-		back = function() { cursor = 0; menu = meMain; fileWrite("config.json", jsonWrite(config)) }
+		func = function() { cursor = 3; menu = meMain; fileWrite("config.json", jsonWrite(config)) }
+		back = function() { cursor = 3; menu = meMain; fileWrite("config.json", jsonWrite(config)) }
 	}
 ]
 
@@ -160,8 +159,8 @@ const fontH = 14
 	},
 	{
 		name = function() { return gvLangObj["menu-commons"]["back"] },
-		func = function() { cursor = 0; menu = meOptions }
-		back = function() { cursor = 0; menu = meOptions }
+		func = function() { cursor = 3; menu = meOptions }
+		back = function() { cursor = 3; menu = meOptions }
 	}
 ]
 

--- a/src/save.nut
+++ b/src/save.nut
@@ -41,8 +41,8 @@
 
 	meLoadGame.push({
 		name = function() { return gvLangObj["menu-commons"]["cancel"] }
-		func = function() { cursor = 0; menu = meMain }
-		back = function() { cursor = 0; menu = meMain }
+		func = function() { cursor = 1; menu = meMain }
+		back = function() { cursor = 1; menu = meMain }
 	})
 
 	menu = meLoadGame


### PR DESCRIPTION
Does improvements and fixes to some menus:

- Makes credits able to be scrolled down in with down and action keys as well. They can also be scrolled up in with the up key. The user cannot go higher than a little above the credits.
- Fixes "menu accept" not appearing in controls menu and makes gamepad controls translatable as well.
- Removes some unneeded lines in `menus.nut`. Also reverts making the game close, when pressing the Pause key on the main menu.
- Makes some menus go back to the cursor on the previous menu, from which they have been opened.