### PR TITLE
Use "Exceptional" language on 1st April

### DIFF
--- a/lang/languages.json
+++ b/lang/languages.json
@@ -1,11 +1,11 @@
 {
 	"languages":[
-		["English","en"],
-		["French","fr"],
-		["Bulgarian","bg"],
-		["Polish","pl"],
-		["Spanish","es"],
-		["Bangla","bn"],
-		["Exceptional","ex"]
+		["English","en",true],
+		["French","fr",true],
+		["Bulgarian","bg",true],
+		["Polish","pl",true],
+		["Spanish","es",true],
+		["Bangla","bn",true],
+		["Exceptional","ex",false]
 	]
 }

--- a/src/languagemenu.nut
+++ b/src/languagemenu.nut
@@ -7,6 +7,7 @@
 	if(languageList==null)
 		languageList = jsonRead(fileRead("lang/languages.json"))
 	for(local i = 0; i < languageList["languages"].len(); i+=1) {
+		if (!languageList["languages"][i][2]) continue //Do not show hidden languages.
 		meLanguage.push(
 			{
 				languageIndex = i,

--- a/tux.brx
+++ b/tux.brx
@@ -121,6 +121,14 @@ startMain()
 menu = meMain
 config.playerChar = "Tux"
 
+//Check if the date is 1st April. If so, set the language to "Exceptional".
+local now = date()
+if(now.day = 1 && now.month == 3) {
+	config.lang = "ex"
+	gvLangObj = jsonRead(fileRead("lang/ex.json"))
+	gvLangObj = mergeTable(gvLangObj, jsonRead(fileRead("lang/ex.json")))
+}
+
 update()
 while(!getQuit() && !gvQuit) //Entire game happens here
 {


### PR DESCRIPTION
Allows the usage of the comedic "Exceptional" language on 1st April. Every time the game starts up, it will check if today is April Fools and set it as the current language if so.

The language is hidden from the menu, but if this is not preferred, it can be reverted. A new property to `languages.json` was added to indicate if a language should be shown on the language menu.