### PR TITLE
Fix icebox solid not being deleted for pipesnakes when hit by a fireball

### DIFF
--- a/src/enemies.nut
+++ b/src/enemies.nut
@@ -399,8 +399,7 @@
 
 		if(icebox != -1) {
 				mapDeleteSolid(icebox)
-				newActor(IceChunks, x, ystart - 6)
-				icebox = -1
+				newActor(IceChunks, x, ystart - 6) // Not resetting icebox here to avoid the ice box solid from remaining in place indefinitely.
 			}
 	}
 


### PR DESCRIPTION
Fixed by removing line 403 in enemies.nut which set icebox to -1 (which on the pipesnake causes the issue that this pull request fixes)