### PR TITLE
Auto save game when worldmap exited

### DIFF
--- a/src/menus.nut
+++ b/src/menus.nut
@@ -137,7 +137,7 @@ const fontH = 14
 	},
 	{
 		name = function() { return gvLangObj["pause-menu"]["quit-game"]},
-		func = function() { startMain(); cursor = 0 }
+		func = function() { saveGame(); startMain(); cursor = 0 }
 	}
 ]
 


### PR DESCRIPTION
Executes `saveGame()` when a worldmap is exited. This allows saving the exact position of the player on the worldmap, so they can continue exactly from where they left off.