### PR TITLE
Mouse cursor - code optimizations

### DIFF
--- a/src/credits.nut
+++ b/src/credits.nut
@@ -28,7 +28,6 @@
 		}
 	}
 	creditsLength += 30 //Padding
-	cursorShown = false //Hide mouse cursor
 	update()
 }
 ::gmCredits <- function(){

--- a/src/cursor.nut
+++ b/src/cursor.nut
@@ -1,9 +1,8 @@
-::cursorShown <- true;
 ::lastMouseX <- mouseX();
 ::lastMouseY <- mouseY();
 
 ::updateCursor <- function() {
-    if(!cursorShown || !config.showcursor) return; //If cursor is hidden or disabled.
+    if(!config.showcursor) return; //If the cursor is disabled.
 
     drawText(font2, mouseX(), mouseY(), "+") //Draw the cursor.
 
@@ -21,8 +20,7 @@
 }
 
 ::processCursorInput <- function() {
-    //If no menu or menu items positions are loaded, cursor is hidden or not enabled.
-    if(menu == [] || menuItemsPos == [] || !cursorShown || !config.showcursor) return;
+    if(!config.showcursor) return; //If the cursor is disabled.
 
     local pos = menuItemsPos[cursor] //Get the position of the currently selected menu item only.
     if(mouseX() >= pos.x - 3 && mouseX() <= pos.x + pos.len - 3 && mouseY() >= pos.y - 6 && mouseY() <= pos.y + fontH - 6) {

--- a/src/gmpause.nut
+++ b/src/gmpause.nut
@@ -10,7 +10,6 @@
 
 ::togglePause <- function() {
 	cursor = 0
-	cursorShown = !cursorShown //Switch the state of the mouse cursor
 	if(gvGameMode == gmPlay) {
 		if(actor.rawin("DeadPlayer")) {
 			startPlay(gvMap.file)

--- a/src/gmplay.nut
+++ b/src/gmplay.nut
@@ -501,9 +501,6 @@
 	//in the log if the map fails, so users can check why a level
 	//refuses to run.
 
-	//Hide mouse cursor
-	cursorShown = false
-
 	//Execute level code
 	print("Running level code...")
 	if(gvMap.data.rawin("properties")) foreach(i in gvMap.data.properties) {

--- a/src/menus.nut
+++ b/src/menus.nut
@@ -21,7 +21,6 @@ const fontH = 14
 	}
 	menuLast = menu
 	menuItemsPos = []
-	cursorShown = true //Show mouse cursor when a menu is entered
 
 	//Draw options
 	//The number
@@ -61,6 +60,10 @@ const fontH = 14
 		drawText(currFont, textX, textY, menu[i].name())
 		menuItemsPos.append({index = i, x = textX, y = textY, len = menu[i].name().len() * fontW})
 	}
+
+	//Mouse cursor update + left click input check
+	updateCursor()
+	if(mouseRelease(0)) processCursorInput()
 
 	//Keyboard input
 	if(getcon("down", "press") || (getcon("down", "hold") && cursorTimer <= 0)) {

--- a/src/overworld.nut
+++ b/src/overworld.nut
@@ -399,9 +399,6 @@
 		camy = 0
 	}
 
-	//Hide mouse cursor
-	cursorShown = false
-
 	//Execute level code
 	print("Running level code...")
 	if(gvMap.data.rawin("properties")) foreach(i in gvMap.data.properties) {

--- a/tux.brx
+++ b/tux.brx
@@ -126,15 +126,11 @@ startMain()
 menu = meMain
 config.playerChar = "Tux"
 
-updateCursor()
-update()
 while(!getQuit() && !gvQuit) //Entire game happens here
 {
 	if(keyPress(k_f11)) toggleFullscreen()
 	if(getcon("pause", "press") && levelEndRunner == 0 && gvGameMode != gmMain) togglePause()
 	gvGameMode()
 	if(keyPress(k_tick)) debugConsole()
-	updateCursor()
-	if(mouseRelease(0)) processCursorInput()
 	update()
 }


### PR DESCRIPTION
Follow-up to pull request #75 - moves executions of `cursorUpdate()` and `processCursorInput()` to `menus.nut`. Removes the `cursorShown` variable as well, since the cursor is now shown only when a menu is.