### PR TITLE
Sound and music toggles

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -25,6 +25,7 @@
 		"language" : "Language",
 		"keyboard" : "Keyboard Controls",
 		"joystick" : "Gamepad Controls",
+		"audio" : "Audio",
 		"cursor" : "Show Mouse Cursor: ",
 		"timers" : "Speedrun Timers",
 		"light" : "Lighting: ",
@@ -39,6 +40,7 @@
 		"language" : "Change game language",
 		"keyboard" : "Change keyboard controls",
 		"joystick" : "Change gamepad controls",
+		"audio" : "Toggle sound and music",
 		"cursor" : "Toggle the mouse cursor",
 		"timers" : "Toggle speedrun timers",
 		"light" : "Toggle light effects",
@@ -72,6 +74,11 @@
 		"cam-right-peek" : "Peek Right",
 		"cam-down-peek" : "Peek Down",
 		"cam-up-peek" : "Peek Up"
+	},
+
+	"audio-menu" : {
+		"sound" : "Sound",
+		"music" : "Music"
 	},
 
 	"menu-commons" : {

--- a/res/map/0-c.json
+++ b/res/map/0-c.json
@@ -291,7 +291,7 @@
                 {
                  "height":16,
                  "id":510,
-                 "name":"if(getcon(\"jump\", \"hold\")) gvPlayer.vspeed = -12; else gvPlayer.vspeed = -8; stopSound(sndSpring); playSound(sndSpring, 0)",
+                 "name":"if(getcon(\"jump\", \"hold\")) gvPlayer.vspeed = -12; else gvPlayer.vspeed = -8; stopSound(sndSpring); soundPlay(sndSpring, 0)",
                  "rotation":0,
                  "type":"",
                  "visible":true,

--- a/src/assets.nut
+++ b/src/assets.nut
@@ -378,13 +378,13 @@ spriteSetBlendMode(sprLightGradient, bm_add)
 //Saved separately so that it can be reused frequently
 ::musInvincible <- loadMusic("res/snd/invincible.ogg")
 
-::songPlay <- function(song) {
+::songPlay <- function(song, forcePlay = false) {
 	gvMusicName = song
-	if(gvMusicName == gvLastSong) return
+	if(gvMusicName == gvLastSong && !forcePlay) return
 
 	deleteMusic(gvMusic)
 	gvMusic = loadMusic(song)
-	playMusic(gvMusic, -1)
+	musicPlay(gvMusic, -1)
 
 	gvLastSong = song
 }

--- a/src/audio.nut
+++ b/src/audio.nut
@@ -1,0 +1,11 @@
+::soundPlay <- function(sound, loops) {
+    if(config.soundenabled) playSound(sound, loops)
+}
+
+::soundPlayChannel <- function(sound, loops, channel) {
+    if(config.soundenabled) playSoundChannel(sound, loops, channel)
+}
+
+::musicPlay <- function(music, loops) {
+    if(config.musicenabled) playMusic(music, loops)
+}

--- a/src/blocks.nut
+++ b/src/blocks.nut
@@ -31,7 +31,7 @@
 						gvPlayer.vspeed = 0
 						deleteActor(id)
 						newActor(WoodChunks, x, y)
-						playSoundChannel(sndBump, 0, 2)
+						soundPlayChannel(sndBump, 0, 2)
 						tileSetSolid(x, y, oldsolid)
 						if(coins > 0) newActor(CoinEffect, x, y - 16)
 					}
@@ -40,7 +40,7 @@
 						gvPlayer.vspeed = 0
 						deleteActor(id)
 						newActor(WoodChunks, x, y)
-						playSoundChannel(sndBump, 0, 2)
+						soundPlayChannel(sndBump, 0, 2)
 						tileSetSolid(x, y, oldsolid)
 						if(coins > 0) newActor(CoinEffect, x, y - 16)
 					}
@@ -49,7 +49,7 @@
 						gvPlayer.vspeed = -2.0
 						deleteActor(id)
 						newActor(WoodChunks, x, y)
-						playSoundChannel(sndBump, 0, 2)
+						soundPlayChannel(sndBump, 0, 2)
 						tileSetSolid(x, y, oldsolid)
 						if(coins > 0) newActor(CoinEffect, x, y - 16)
 					}
@@ -59,21 +59,21 @@
 						vspeed = -2
 						coins--
 						newActor(CoinEffect, x, y - 16)
-						playSoundChannel(sndBump, 0, 2)
+						soundPlayChannel(sndBump, 0, 2)
 					}
 
 					if(gvPlayer.rawin("anSlide")) if((abs(gvPlayer.hspeed) >= 4.5 || (game.weapon == 4 && gvPlayer.vspeed >= 2)) && gvPlayer.anim == gvPlayer.anSlide) if(hitTest(slideshape, gvPlayer.shape)) {
 						vspeed = -2
 						coins--
 						newActor(CoinEffect, x, y - 16)
-						playSoundChannel(sndBump, 0, 2)
+						soundPlayChannel(sndBump, 0, 2)
 					}
 
 					if(gvPlayer.rawin("anStomp")) if(hitTest(gvPlayer.shape, shape) && gvPlayer.anim == gvPlayer.anStomp) {
 						vspeed = -2
 						coins--
 						newActor(CoinEffect, x, y - 16)
-						playSoundChannel(sndBump, 0, 2)
+						soundPlayChannel(sndBump, 0, 2)
 					}
 				}
 			}
@@ -84,7 +84,7 @@
 				if(coins <= 1) {
 					deleteActor(id)
 					newActor(WoodChunks, x, y)
-					playSoundChannel(sndBump, 0, 2)
+					soundPlayChannel(sndBump, 0, 2)
 					tileSetSolid(x, y, oldsolid)
 					if(coins > 0) newActor(CoinEffect, x, y - 16)
 				}
@@ -92,7 +92,7 @@
 					vspeed = -2
 					coins--
 					newActor(CoinEffect, x, y - 16)
-					playSoundChannel(sndBump, 0, 2)
+					soundPlayChannel(sndBump, 0, 2)
 				}
 			}
 		}
@@ -102,7 +102,7 @@
 				if(coins <= 1) {
 					deleteActor(id)
 					newActor(WoodChunks, x, y)
-					playSoundChannel(sndBump, 0, 2)
+					soundPlayChannel(sndBump, 0, 2)
 					tileSetSolid(x, y, oldsolid)
 					if(coins > 0) newActor(CoinEffect, x, y - 16)
 				}
@@ -110,7 +110,7 @@
 					vspeed = -2
 					coins--
 					newActor(CoinEffect, x, y - 16)
-					playSoundChannel(sndBump, 0, 2)
+					soundPlayChannel(sndBump, 0, 2)
 				}
 			}
 		}
@@ -120,7 +120,7 @@
 				if(coins <= 1) {
 					deleteActor(id)
 					newActor(WoodChunks, x, y)
-					playSoundChannel(sndBump, 0, 2)
+					soundPlayChannel(sndBump, 0, 2)
 					tileSetSolid(x, y, oldsolid)
 					if(coins > 0) newActor(CoinEffect, x, y - 16)
 				}
@@ -128,7 +128,7 @@
 					vspeed = -2
 					coins--
 					newActor(CoinEffect, x, y - 16)
-					playSoundChannel(sndBump, 0, 2)
+					soundPlayChannel(sndBump, 0, 2)
 				}
 			}
 		}
@@ -165,7 +165,7 @@
 				tileSetSolid(x, y, oldsolid)
 				deleteActor(id)
 				newActor(IceChunks, x, y)
-				playSound(sndBump, 0)
+				soundPlay(sndBump, 0)
 			}
 
 			if((abs(gvPlayer.hspeed) >= 3.5 || (game.weapon == 4 && gvPlayer.vspeed >= 2)) && gvPlayer.anim == gvPlayer.anSlide) if(hitTest(slideshape, gvPlayer.shape)) {
@@ -173,7 +173,7 @@
 				tileSetSolid(x, y, oldsolid)
 				deleteActor(id)
 				newActor(IceChunks, x, y)
-				playSound(sndBump, 0)
+				soundPlay(sndBump, 0)
 			}
 
 			if(gvPlayer.rawin("anStomp")) if(hitTest(gvPlayer.shape, shape) && gvPlayer.anim == gvPlayer.anStomp) {
@@ -181,7 +181,7 @@
 				tileSetSolid(x, y, oldsolid)
 				deleteActor(id)
 				newActor(IceChunks, x, y)
-				playSound(sndBump, 0)
+				soundPlay(sndBump, 0)
 			}
 		}
 
@@ -190,7 +190,7 @@
 			deleteActor(id)
 			deleteActor(i.id)
 			newActor(Poof, x, y)
-			playSound(sndFlame, 0)
+			soundPlay(sndFlame, 0)
 		}
 
 		if(actor.rawin("FlameBreath")) foreach(i in actor["FlameBreath"])  if(hitTest(fireshape, i.shape)) {
@@ -198,7 +198,7 @@
 			deleteActor(id)
 			deleteActor(i.id)
 			newActor(Poof, x, y)
-			playSound(sndFlame, 0)
+			soundPlay(sndFlame, 0)
 		}
 
 		if(actor.rawin("ExplodeN")) foreach(i in actor["ExplodeN"])  if(hitTest(fireshape, i.shape)) {
@@ -206,7 +206,7 @@
 			deleteActor(id)
 			newActor(IceChunks, x, y)
 			newActor(Poof, x, y)
-			playSound(sndFlame, 0)
+			soundPlay(sndFlame, 0)
 		}
 
 		if(actor.rawin("ExplodeF")) foreach(i in actor["ExplodeF"])  if(hitTest(fireshape, i.shape)) {
@@ -214,7 +214,7 @@
 			deleteActor(id)
 			newActor(IceChunks, x, y)
 			newActor(Poof, x, y)
-			playSound(sndFlame, 0)
+			soundPlay(sndFlame, 0)
 		}
 
 		drawSpriteZ(2, sprIceBlock, 0, x - 8 - camx, y - 8 - camy)
@@ -330,7 +330,7 @@
 			gvPlayer.vspeed = 0
 			full = false
 			vspeed = -2
-			playSound(sndBump, 0)
+			soundPlay(sndBump, 0)
 		}
 
 		v += vspeed
@@ -370,7 +370,7 @@
 			gvPlayer.vspeed = 0
 			full = false
 			vspeed = -1
-			playSound(sndBump, 0)
+			soundPlay(sndBump, 0)
 		}
 
 		v += vspeed
@@ -409,7 +409,7 @@
 			if(hitTest(shape, gvPlayer.shape)) if(gvPlayer.vspeed < 0 && v == 0) if(full){
 				gvPlayer.vspeed = 0
 				vspeed = -1
-				playSound(sndBump, 0)
+				soundPlay(sndBump, 0)
 				gvInfoBox = text
 			}
 
@@ -482,7 +482,7 @@
 			if(hitTest(shape, gvPlayer.shape)) if(gvPlayer.vspeed < 0 && v == 0) if(full){
 				gvPlayer.vspeed = 1
 				vspeed = -1
-				playSound(sndBump, 0)
+				soundPlay(sndBump, 0)
 			}
 
 			shape.setPos(x, y - 1)
@@ -490,7 +490,7 @@
 				gvPlayer.vspeed = -4
 				if(getcon("jump", "hold")) gvPlayer.vspeed = -7.5
 				vspeed = 1
-				playSound(sndBump, 0)
+				soundPlay(sndBump, 0)
 			}
 
 			if(gvInfoBox == text) if(inDistance2(x, y, gvPlayer.x, gvPlayer.y, 64)) gvInfoBox = ""
@@ -521,7 +521,7 @@
 			game.check = true
 			game.chx = x
 			game.chy = y
-			playSoundChannel(sndBell, 0, 4)
+			soundPlayChannel(sndBell, 0, 4)
 			if(game.difficulty < 3) {
 				if(game.health < game.maxHealth) game.health += 2
 				else if(game.subitem == 0) game.subitem = 5
@@ -565,7 +565,7 @@
 			if(gvPlayer) if(hitTest(shape, gvPlayer.shape)) {
 				gothit = true
 				stopSound(sndFizz)
-				playSound(sndFizz, 0)
+				soundPlay(sndFizz, 0)
 			}
 		}
 
@@ -703,7 +703,7 @@
 				tileSetSolid(x, y, oldsolid)
 				deleteActor(id)
 				newActor(Poof, x, y)
-				playSound(sndBump, 0)
+				soundPlay(sndBump, 0)
 				newActor(Darknyan, x, y - 16)
 			}
 
@@ -736,7 +736,7 @@
 				tileSetSolid(x, y, oldsolid)
 				deleteActor(id)
 				newActor(Poof, x, y)
-				playSound(sndBump, 0)
+				soundPlay(sndBump, 0)
 				newActor(MuffinBomb, x, y - 16)
 			}
 
@@ -811,7 +811,7 @@
 						deleteActor(id)
 						newActor(Poof, x, y)
 						stopSound(sndBump)
-						playSound(sndBump, 0)
+						soundPlay(sndBump, 0)
 					}
 					break
 				case 1:
@@ -820,7 +820,7 @@
 						deleteActor(id)
 						newActor(Poof, x, y)
 						stopSound(sndBump)
-						playSound(sndBump, 0)
+						soundPlay(sndBump, 0)
 					}
 					break
 				case 2:
@@ -829,7 +829,7 @@
 						deleteActor(id)
 						newActor(Poof, x, y)
 						stopSound(sndBump)
-						playSound(sndBump, 0)
+						soundPlay(sndBump, 0)
 					}
 					break
 				case 3:
@@ -838,7 +838,7 @@
 						deleteActor(id)
 						newActor(Poof, x, y)
 						stopSound(sndBump)
-						playSound(sndBump, 0)
+						soundPlay(sndBump, 0)
 					}
 					break
 			}
@@ -934,21 +934,21 @@
 			deleteActor(id)
 			deleteActor(i.id)
 			newActor(Flame, x, y)
-			playSound(sndFlame, 0)
+			soundPlay(sndFlame, 0)
 		}
 
 		if(actor.rawin("ExplodeF")) foreach(i in actor["ExplodeF"])  if(hitTest(fireshape, i.shape)) {
 			tileSetSolid(x, y, 0)
 			deleteActor(id)
 			newActor(Flame, x, y)
-			playSound(sndFlame, 0)
+			soundPlay(sndFlame, 0)
 		}
 
 		if(actor.rawin("Flame")) foreach(i in actor["Flame"]) if(inDistance2(x, y, i.x, i.y, 20) && i.frame >= 2) {
 			tileSetSolid(x, y, 0)
 			deleteActor(id)
 			newActor(Flame, x, y)
-			playSound(sndFlame, 0)
+			soundPlay(sndFlame, 0)
 		}
 
 		drawSprite(sprFireBlock, 0, x - 8 - camx, y - 8 - camy)

--- a/src/bosses.nut
+++ b/src/bosses.nut
@@ -290,7 +290,7 @@
 		eventTimer--
 		if(eventTimer < 100) anim = anCheer
 		else anim = anIdle
-		if(eventTimer == 100) playSound(sndGrowl, 0)
+		if(eventTimer == 100) soundPlay(sndGrowl, 0)
 		if(eventTimer == 0) {
 			eventTimer = 60
 			routine = ruIdle
@@ -389,7 +389,7 @@
 			frame = anim[0]
 			routine = ruDizzy
 			eventTimer = 240
-			playSound(sndGrowl, 0)
+			soundPlay(sndGrowl, 0)
 		}
 	}
 
@@ -438,7 +438,7 @@
 		if(health <= 0) return
 		blinking = 12.0
 		health--
-		playSound(sndBossHit, 0)
+		soundPlay(sndBossHit, 0)
 	}
 
 	function hurtFire() { hurtBlast() }
@@ -457,8 +457,8 @@
 		}
 		health -= 4
 		if(gvPlayer) if(gvPlayer.rawin("anStomp")) if(gvPlayer.anim == gvPlayer.anStomp) health -= 4
-		if(health > 0) playSound(sndBossHit, 0)
-		else playSound(sndDie, 0)
+		if(health > 0) soundPlay(sndBossHit, 0)
+		else soundPlay(sndDie, 0)
 	}
 
 	function _typeof() { return "Boss" }

--- a/src/cursor.nut
+++ b/src/cursor.nut
@@ -26,7 +26,7 @@
 	if(mouseX() >= pos.x - 3 && mouseX() <= pos.x + pos.len - 3 && mouseY() >= pos.y && mouseY() <= pos.y + fontH) {
 		if(menu[pos.index].rawin("disabled")) return;
 		menu[pos.index].func()
-		playSound(sndMenuSelect, 0)
+		soundPlay(sndMenuSelect, 0)
 		return
 	}
 }

--- a/src/cursor.nut
+++ b/src/cursor.nut
@@ -22,7 +22,7 @@
 ::processCursorInput <- function() {
 	if(!config.showcursor) return; //If the cursor is disabled.
 
-	local pos = menuItemsPos[cursor - cursorOffset] //Get the position of the currently selected menu item only.
+	local pos = menuItemsPos[(menu.len() > menuMax ? cursor - cursorOffset : cursor)] //Get the position of the currently selected menu item only.
 	if(mouseX() >= pos.x - 3 && mouseX() <= pos.x + pos.len - 3 && mouseY() >= pos.y && mouseY() <= pos.y + fontH) {
 		if(menu[pos.index].rawin("disabled")) return;
 		menu[pos.index].func()

--- a/src/effects.nut
+++ b/src/effects.nut
@@ -135,7 +135,7 @@
 		game.levelCoins += value
 		base.constructor(_x, _y)
 		stopSound(sndCoin)
-		playSound(sndCoin, 0)
+		soundPlay(sndCoin, 0)
 	}
 
 	function run() {
@@ -160,7 +160,7 @@
 
 	constructor(_x, _y, _arr = null) {
 		base.constructor(_x, _y)
-		playSound(sndIceBreak, 0)
+		soundPlay(sndIceBreak, 0)
 	}
 
 	function run() {

--- a/src/enemies.nut
+++ b/src/enemies.nut
@@ -115,7 +115,7 @@
 	function hurtinvinc() {
 		newActor(Poof, x, y)
 		deleteActor(id)
-		playSound(sndFlame, 0)
+		soundPlay(sndFlame, 0)
 	}
 
 	function hurtblast() { gethurt() }
@@ -258,12 +258,12 @@
 				actor[c].spin = (gvPlayer.hspeed * 7)
 				actor[c].angle = 180
 				deleteActor(id)
-				playSound(sndKick, 0)
+				soundPlay(sndKick, 0)
 			}
 			else if(getcon("jump", "hold")) gvPlayer.vspeed = -8.0
 			else {
 				gvPlayer.vspeed = -4.0
-				playSound(sndSquish, 0)
+				soundPlay(sndSquish, 0)
 			}
 			if(gvPlayer.anim == gvPlayer.anJumpT || gvPlayer.anim == gvPlayer.anFall) {
 				gvPlayer.anim = gvPlayer.anJumpU
@@ -288,7 +288,7 @@
 		actor[c].spin = (4 * 7)
 		actor[c].angle = 180
 		deleteActor(id)
-		playSound(sndKick, 0)
+		soundPlay(sndKick, 0)
 		if(icebox != -1) mapDeleteSolid(icebox)
 
 	}
@@ -296,7 +296,7 @@
 	function hurtfire() {
 		newActor(Flame, x, y - 1)
 		deleteActor(id)
-		playSound(sndFlame, 0)
+		soundPlay(sndFlame, 0)
 
 		if(randInt(20) == 0) {
 			local a = actor[newActor(MuffinBlue, x, y)]
@@ -369,7 +369,7 @@
 			newActor(Poof, x, ystart - 8)
 			newActor(Poof, x, ystart + 8)
 			deleteActor(id)
-			playSound(sndKick, 0)
+			soundPlay(sndKick, 0)
 
 			if(icebox != -1) {
 				mapDeleteSolid(icebox)
@@ -385,7 +385,7 @@
 		newActor(Poof, x, ystart - 6)
 		newActor(Poof, x, ystart + 8)
 		deleteActor(id)
-		playSound(sndFlame, 0)
+		soundPlay(sndFlame, 0)
 
 		if(icebox != -1) {
 				mapDeleteSolid(icebox)
@@ -398,7 +398,7 @@
 		newActor(Flame, x, ystart - 6)
 		newActor(Flame, x, ystart + 8)
 		deleteActor(id)
-		playSound(sndFlame, 0)
+		soundPlay(sndFlame, 0)
 
 		if(icebox != -1) {
 				mapDeleteSolid(icebox)
@@ -660,7 +660,7 @@
 		if(squish) return
 		if(frozen) frozen = 0
 		stopSound(sndFizz)
-		playSound(sndFizz, 0)
+		soundPlay(sndFizz, 0)
 		if(icebox != -1) {
 			mapDeleteSolid(icebox)
 			newActor(IceChunks, x, y)
@@ -673,7 +673,7 @@
 		if(squish) return
 
 		stopSound(sndFizz)
-		playSound(sndFizz, 0)
+		soundPlay(sndFizz, 0)
 		if(getcon("jump", "hold")) gvPlayer.vspeed = -8
 		else gvPlayer.vspeed = -4
 		if(gvPlayer.anim == gvPlayer.anJumpT || gvPlayer.anim == gvPlayer.anFall) {
@@ -692,7 +692,7 @@
 		if(!burnt) {
 			newActor(BadExplode, x, y - 1)
 			deleteActor(id)
-			playSound(sndFlame, 0)
+			soundPlay(sndFlame, 0)
 
 			burnt = true
 		}
@@ -711,7 +711,7 @@
 		base.constructor(_x, _y)
 
 		stopSound(sndExplodeF)
-		playSound(sndExplodeF, 0)
+		soundPlay(sndExplodeF, 0)
 
 		shape = Cir(x, y, 16)
 	}
@@ -830,7 +830,7 @@
 	function gethurt() {
 		newActor(Poof, x, y)
 		deleteActor(id)
-		playSound(sndSquish, 0)
+		soundPlay(sndSquish, 0)
 		if(keyDown(config.key.jump)) gvPlayer.vspeed = -8
 		else gvPlayer.vspeed = -4
 
@@ -957,11 +957,11 @@
 		actor[c].vspeed = -abs(gvPlayer.hspeed * 1.1)
 		actor[c].hspeed = (gvPlayer.hspeed / 16)
 		deleteActor(id)
-		playSound(sndKick, 0)
+		soundPlay(sndKick, 0)
 		if(getcon("jump", "hold")) gvPlayer.vspeed = -5
 		else {
 			gvPlayer.vspeed = -2
-			playSound(sndSquish, 0)
+			soundPlay(sndSquish, 0)
 		}
 		if(gvPlayer.anim == gvPlayer.anJumpT || gvPlayer.anim == gvPlayer.anFall) {
 			gvPlayer.anim = gvPlayer.anJumpU
@@ -979,7 +979,7 @@
 		actor[c].vspeed = -abs(gvPlayer.hspeed * 1.1)
 		actor[c].hspeed = (gvPlayer.hspeed / 16)
 		deleteActor(id)
-		playSound(sndKick, 0)
+		soundPlay(sndKick, 0)
 		if(icebox != -1) {
 			mapDeleteSolid(icebox)
 			newActor(IceChunks, x, y)
@@ -1060,7 +1060,7 @@
 		else actor[c].spin = 1
 		actor[c].gravity = 0.02
 		deleteActor(id)
-		playSound(sndKick, 0)
+		soundPlay(sndKick, 0)
 		game.enemies--
 		newActor(Poof, x + 8, y)
 		newActor(Poof, x - 8, y)
@@ -1167,7 +1167,7 @@
 		else actor[c].spin = 1
 		actor[c].gravity = 0.02
 		deleteActor(id)
-		playSound(sndKick, 0)
+		soundPlay(sndKick, 0)
 		game.enemies--
 		newActor(Poof, x + 8, y)
 		newActor(Poof, x - 8, y)
@@ -1268,7 +1268,7 @@
 		else actor[c].spin = 1
 		actor[c].gravity = 0.01
 		deleteActor(id)
-		playSound(sndKick, 0)
+		soundPlay(sndKick, 0)
 		game.enemies--
 		newActor(Poof, x, y)
 	}
@@ -1318,7 +1318,7 @@
 			}
 			newActor(Poof, x, y - 1)
 			deleteActor(id)
-			playSound(sndFlame, 0)
+			soundPlay(sndFlame, 0)
 
 		}
 	}
@@ -1471,7 +1471,7 @@
 		else actor[c].spin = 1
 		actor[c].gravity = 0.02
 		deleteActor(id)
-		playSound(sndKick, 0)
+		soundPlay(sndKick, 0)
 		game.enemies--
 		newActor(Poof, x + 8, y)
 		newActor(Poof, x - 8, y)
@@ -1498,7 +1498,7 @@
 
 		if(gvPlayer) if(abs(y - gvPlayer.y) < 128 && y < gvPlayer.y && abs(x - gvPlayer.x) < 8 && !counting) {
 			counting = true
-			playSound(sndIcicle, 0)
+			soundPlay(sndIcicle, 0)
 		}
 
 		if(counting && timer > 0) timer--
@@ -1605,15 +1605,15 @@
 		actor[c].spin = (gvPlayer.hspeed * 6)
 		actor[c].angle = 180
 		deleteActor(id)
-		playSound(sndKick, 0)
+		soundPlay(sndKick, 0)
 
 		if(getcon("jump", "hold")) {
 			gvPlayer.vspeed = -8
-			playSound(sndSquish, 0)
+			soundPlay(sndSquish, 0)
 		}
 		else {
 			gvPlayer.vspeed = -4
-			playSound(sndSquish, 0)
+			soundPlay(sndSquish, 0)
 		}
 
 		if(gvPlayer.anim == gvPlayer.anJumpT || gvPlayer.anim == gvPlayer.anFall) {
@@ -1730,7 +1730,7 @@
 		}
 		newActor(Poof, x, y - 1)
 		deleteActor(id)
-		playSound(sndFlame, 0)
+		soundPlay(sndFlame, 0)
 
 
 	}
@@ -1738,7 +1738,7 @@
 	function hurtfire() {
 		newActor(Flame, x, y - 1)
 		deleteActor(id)
-		playSound(sndFlame, 0)
+		soundPlay(sndFlame, 0)
 
 	}
 
@@ -1885,7 +1885,7 @@
 					chasing = true
 					squishTime = 0
 					stopSound(sndFizz)
-					playSound(sndFizz, 0)
+					soundPlay(sndFizz, 0)
 				}
 				if(squishTime >= 300 && chasing) {
 					deleteActor(id)
@@ -1939,7 +1939,7 @@
 			gvPlayer.anim = gvPlayer.anJumpU
 			gvPlayer.frame = gvPlayer.anJumpU[0]
 		}
-		playSound(sndKick, 0)
+		soundPlay(sndKick, 0)
 
 		squish = true
 	}
@@ -1952,7 +1952,7 @@
 		if(!burnt) {
 			newActor(BadExplode, x, y - 1)
 			deleteActor(id)
-			playSound(sndFlame, 0)
+			soundPlay(sndFlame, 0)
 
 			burnt = true
 		}
@@ -1987,7 +1987,7 @@
 		base.constructor(_x, _y)
 
 		stopSound(sndExplodeF)
-		playSound(sndExplodeF, 0)
+		soundPlay(sndExplodeF, 0)
 
 		shape = Rec(x, y, 16, 16, 0)
 	}
@@ -2143,7 +2143,7 @@
 		if(squish) return
 		if(frozen) frozen = 0
 		stopSound(sndFizz)
-		playSound(sndFizz, 0)
+		soundPlay(sndFizz, 0)
 		if(icebox != -1) {
 			mapDeleteSolid(icebox)
 			newActor(IceChunks, x, y)
@@ -2156,7 +2156,7 @@
 		if(squish) return
 
 		stopSound(sndFizz)
-		playSound(sndFizz, 0)
+		soundPlay(sndFizz, 0)
 		if(getcon("jump", "hold")) gvPlayer.vspeed = -8
 		else gvPlayer.vspeed = -4
 		if(gvPlayer.anim == gvPlayer.anJumpT || gvPlayer.anim == gvPlayer.anFall) {
@@ -2245,7 +2245,7 @@
 					if(gvPlayer) if(icebox == -1 && !hitTest(shape, gvPlayer.shape)) {
 						newActor(Flame, x, y - 1)
 						deleteActor(id)
-						playSound(sndFlame, 0)
+						soundPlay(sndFlame, 0)
 					}
 
 					//Draw
@@ -2302,7 +2302,7 @@
 			else if(getcon("jump", "hold")) gvPlayer.vspeed = -8.0
 			else {
 				gvPlayer.vspeed = -4.0
-				playSound(sndSquish, 0)
+				soundPlay(sndSquish, 0)
 			}
 			if(gvPlayer.anim == gvPlayer.anJumpT || gvPlayer.anim == gvPlayer.anFall) {
 				gvPlayer.anim = gvPlayer.anJumpU
@@ -2322,7 +2322,7 @@
 	function hurtblast() {
 		newActor(Poof, x, y)
 		deleteActor(id)
-		playSound(sndFlame, 0)
+		soundPlay(sndFlame, 0)
 		if(icebox != -1) mapDeleteSolid(icebox)
 
 	}
@@ -2463,12 +2463,12 @@
 				actor[c].spin = (gvPlayer.hspeed * 7)
 				actor[c].angle = 180
 				deleteActor(id)
-				playSound(sndKick, 0)
+				soundPlay(sndKick, 0)
 			}
 			else if(getcon("jump", "hold")) gvPlayer.vspeed = -8.0
 			else {
 				gvPlayer.vspeed = -4.0
-				playSound(sndSquish, 0)
+				soundPlay(sndSquish, 0)
 			}
 			if(gvPlayer.anim == gvPlayer.anJumpT || gvPlayer.anim == gvPlayer.anFall) {
 				gvPlayer.anim = gvPlayer.anJumpU
@@ -2493,7 +2493,7 @@
 		actor[c].spin = (4 * 7)
 		actor[c].angle = 180
 		deleteActor(id)
-		playSound(sndKick, 0)
+		soundPlay(sndKick, 0)
 		if(icebox != -1) mapDeleteSolid(icebox)
 
 	}
@@ -2501,7 +2501,7 @@
 	function hurtfire() {
 		newActor(Flame, x, y - 1)
 		deleteActor(id)
-		playSound(sndFlame, 0)
+		soundPlay(sndFlame, 0)
 
 		if(randInt(50) == 0) {
 			local a = actor[newActor(MuffinRed, x, y)]

--- a/src/global.nut
+++ b/src/global.nut
@@ -122,6 +122,8 @@
 	light = true
 	showcursor = true
 	usefilter = false
+	soundenabled = true
+	musicenabled = true
 }
 
 ::contribDidRun <- {}

--- a/src/gmplay.nut
+++ b/src/gmplay.nut
@@ -699,7 +699,7 @@
 		if(gvWarning < 180) {
 			if(gvWarning == 0 || gvWarning == 90) {
 				stopChannel(4)
-				playSoundChannel(sndWarning, 0, 4)
+				soundPlayChannel(sndWarning, 0, 4)
 			}
 			drawSpriteEx(sprWarning, 0, screenW() / 2, screenH() / 2, 0, 0, 1, 1, abs(sin(gvWarning / 30.0)))
 			gvWarning += 1.5

--- a/src/items.nut
+++ b/src/items.nut
@@ -84,7 +84,7 @@
 			deleteActor(id)
 			game.berries++
 			stopSound(sndGulp)
-			playSound(sndGulp, 0)
+			soundPlay(sndGulp, 0)
 		}
 	}
 
@@ -107,7 +107,7 @@
 		drawSprite(sprHerring, 0, x - camx, y - camy + ((getFrames() / 16) % 2 == 0).tointeger())
 		if(gvPlayer) if(inDistance2(x, y, gvPlayer.x, gvPlayer.y + 2, 16)) {
 			deleteActor(id)
-			playSoundChannel(sndFish, 0, 1)
+			soundPlayChannel(sndFish, 0, 1)
 			game.levelredcoins++
 		}
 	}
@@ -136,7 +136,7 @@
 				game.maxEnergy = 4 - game.difficulty + game.fireBonus
 				game.weapon = 1
 			}
-			playSoundChannel(sndHeal, 0, 1)
+			soundPlayChannel(sndHeal, 0, 1)
 			if(gvPlayer.rawin("tftime")) gvPlayer.tftime = 0
 		}
 	}
@@ -165,7 +165,7 @@
 				game.maxEnergy = 4 - game.difficulty + game.iceBonus
 				game.weapon = 2
 			}
-			playSoundChannel(sndHeal, 0, 1)
+			soundPlayChannel(sndHeal, 0, 1)
 			if(gvPlayer.rawin("tftime")) gvPlayer.tftime = 0
 		}
 	}
@@ -234,7 +234,7 @@
 			}
 			else if(game.subitem != 6 && (game.subitem == 0 || willwrite)) game.subitem = 5
 			deleteActor(id)
-			playSoundChannel(sndHeal, 0, 1)
+			soundPlayChannel(sndHeal, 0, 1)
 		}
 
 		drawSprite(sprMuffin, 0, x - camx, y - camy)
@@ -305,7 +305,7 @@
 			}
 			else game.subitem = 6
 			deleteActor(id)
-			playSoundChannel(sndHeal, 0, 1)
+			soundPlayChannel(sndHeal, 0, 1)
 		}
 
 		drawSprite(sprMuffin, 1, x - camx, y - camy)
@@ -454,7 +454,7 @@
 		if(gvPlayer) if(inDistance2(x, y, gvPlayer.x, gvPlayer.y, 16)) {
 			gvPlayer.invincible = 645
 			deleteActor(id)
-			playMusic(musInvincible, -1)
+			musicPlay(musInvincible, -1)
 			gvLastSong = ""
 		}
 
@@ -492,7 +492,7 @@
 		drawSprite(sprAirFeather, frame, x - camx, y - camy)
 
 		if(gvPlayer) if(hitTest(shape, gvPlayer.shape)){
-			playSoundChannel(sndHeal, 0, 1)
+			soundPlayChannel(sndHeal, 0, 1)
 			if(game.weapon == 0) {
 				game.weapon = 3
 				game.maxEnergy = 4 - game.difficulty + game.airBonus
@@ -544,7 +544,7 @@
 
 		if(gvPlayer) if(inDistance2(x, y, gvPlayer.x, gvPlayer.y, 16)) {
 			game.canres = true
-			playSound(snd1up, 0)
+			soundPlay(snd1up, 0)
 			deleteActor(id)
 		}
 
@@ -634,7 +634,7 @@
 				game.maxEnergy = 4 - game.difficulty + game.earthBonus
 				game.weapon = 4
 			}
-			playSoundChannel(sndHeal, 0, 1)
+			soundPlayChannel(sndHeal, 0, 1)
 			if(gvPlayer.rawin("tftime")) gvPlayer.tftime = 0
 		}
 	}
@@ -726,7 +726,7 @@
 					gvKeyCopper = true
 					break
 			}
-			playSound(snd1up, 0)
+			soundPlay(snd1up, 0)
 		}
 
 		//Draw

--- a/src/konqi.nut
+++ b/src/konqi.nut
@@ -427,24 +427,24 @@
 						}
 						if(game.weapon != 3) {
 							stopSound(sndJump)
-							playSound(sndJump, 0)
+							soundPlay(sndJump, 0)
 						}
 						else {
 							stopSound(sndFlap)
-							playSound(sndFlap, 0)
+							soundPlay(sndFlap, 0)
 						}
 					}
 					else if(freeDown && anim != anClimb && !placeFree(x - 2, y) && anim != anWall && hspeed <= 0 && tileGetSolid(x - 12, y - 12) != 40 && tileGetSolid(x - 12, y + 12) != 40 && tileGetSolid(x - 12, y) != 40) {
 						flip = 0
 						anim = anWall
 						frame = anim[0]
-						playSound(sndWallkick, 0)
+						soundPlay(sndWallkick, 0)
 					}
 					else if(freeDown && anim != anClimb && !placeFree(x + 2, y) && anim != anWall && hspeed >= 0 && tileGetSolid(x + 12, y - 12) != 40 && tileGetSolid(x + 12, y + 12) != 40 && tileGetSolid(x + 12, y) != 40) {
 						flip = 1
 						anim = anWall
 						frame = anim[0]
-						playSound(sndWallkick, 0)
+						soundPlay(sndWallkick, 0)
 					}
 					else if(floor(energy) > 0 && game.weapon == 3 && getcon("jump", "press")) {
 						if(vspeed > 0) vspeed = 0.0
@@ -457,11 +457,11 @@
 						}
 						if(game.weapon != 3) {
 							stopSound(sndJump)
-							playSound(sndJump, 0)
+							soundPlay(sndJump, 0)
 						}
 						else {
 							stopSound(sndFlap)
-							playSound(sndFlap, 0)
+							soundPlay(sndFlap, 0)
 						}
 						energy--
 					}
@@ -503,14 +503,14 @@
 						anim = anDive
 						frame = anim[0]
 						flip = 0
-						playSoundChannel(sndSlide, 0, 0)
+						soundPlayChannel(sndSlide, 0, 0)
 					}
 
 					if(placeFree(x - 2, y + 1) || hspeed <= -1.5) {
 						anim = anDive
 						frame = anim[0]
 						flip = 1
-						playSoundChannel(sndSlide, 0, 0)
+						soundPlayChannel(sndSlide, 0, 0)
 					}
 				}
 
@@ -621,7 +621,7 @@
 					if(cooldown > 0) break
 					if(getcon("shoot", "press")) {
 						cooldown = 60
-						playSoundChannel(sndFlame, 0, 0)
+						soundPlayChannel(sndFlame, 0, 0)
 					}
 					break
 				case 1:
@@ -636,7 +636,7 @@
 						if(!flip) c.hspeed = 5
 						else c.hspeed = -5
 						c.vspeed = -0.5
-						playSound(sndFireball, 0)
+						soundPlay(sndFireball, 0)
 						if(getcon("up", "hold")) {
 							c.vspeed = -2.5
 							c.hspeed /= 1.5
@@ -650,7 +650,7 @@
 					if(cooldown > 0) break
 					if(getcon("shoot", "press")) {
 						cooldown = 60
-						playSoundChannel(sndFlame, 0, 0)
+						soundPlayChannel(sndFlame, 0, 0)
 					}
 					break
 
@@ -658,7 +658,7 @@
 					if(cooldown > 0) break
 					if(getcon("shoot", "press")) {
 						cooldown = 60
-						playSoundChannel(sndFlame, 0, 0)
+						soundPlayChannel(sndFlame, 0, 0)
 					}
 					break
 
@@ -666,7 +666,7 @@
 					if(getcon("shoot", "press") && (anim != anHurt)) {
 						anim = anDive
 						frame = anim[0]
-						playSoundChannel(sndSlide, 0, 0)
+						soundPlayChannel(sndSlide, 0, 0)
 						if(flip == 0 && hspeed < 2) hspeed = 2
 						if(flip == 1 && hspeed > -2) hspeed = -2
 					}
@@ -786,7 +786,7 @@
 						local c = actor[newActor(Fireball, x + fx, y - 4)]
 						if(!flip) c.hspeed = 3
 						else c.hspeed = -3
-						playSound(sndFireball, 0)
+						soundPlay(sndFireball, 0)
 						if(getcon("up", "hold")) {
 							c.vspeed = -3
 							if(hspeed != 0) c.hspeed *= 0.75
@@ -819,7 +819,7 @@
 						local c = actor[newActor(Iceball, x + fx, y)]
 						if(!flip) c.hspeed = 3
 						else c.hspeed = -3
-						playSound(sndFireball, 0)
+						soundPlay(sndFireball, 0)
 						if(getcon("up", "hold")) {
 							c.vspeed = -3
 							if(hspeed != 0) c.hspeed *= 0.75
@@ -917,7 +917,7 @@
 		if(hurt > 0 && invincible == 0) {
 			if(blinking == 0) {
 				blinking = 60
-				playSound(sndHurt, 0)
+				soundPlay(sndHurt, 0)
 				if(game.weapon == 4 && anim == anSlide && energy > 0) {
 					energy--
 					firetime = 120
@@ -1050,7 +1050,7 @@
 				game.maxEnergy++
 				game.subitem = 0
 				tftime = 0
-				playSound(sndHeal, 0)
+				soundPlay(sndHeal, 0)
 			}
 			return
 		}
@@ -1101,7 +1101,7 @@
 	constructor(_x, _y, _arr = null) {
 		base.constructor(_x, _y)
 		stopMusic()
-		playSound(sndDie, 0)
+		soundPlay(sndDie, 0)
 	}
 
 	function run() {

--- a/src/levelend.nut
+++ b/src/levelend.nut
@@ -41,7 +41,7 @@
 
 		game.coins += game.levelCoins
 
-		playSound(sndWin, 0)
+		soundPlay(sndWin, 0)
 		stopMusic()
 
 		levelEndRunner = newActor(LevelEnder, 0, 0)

--- a/src/menus.nut
+++ b/src/menus.nut
@@ -75,7 +75,7 @@ const fontH = 14
 		}
 		if(getcon("down", "press")) cursorTimer = 40
 		else cursorTimer = 10
-		playSound(sndMenuMove, 0)
+		soundPlay(sndMenuMove, 0)
 	}
 
 	if(getcon("up", "press") || (getcon("up", "hold") && cursorTimer <= 0)) {
@@ -87,7 +87,7 @@ const fontH = 14
 		}
 		if(getcon("up", "press")) cursorTimer = 40
 		else cursorTimer = 10
-		playSound(sndMenuMove, 0)
+		soundPlay(sndMenuMove, 0)
 	}
 
 	if(getcon("down", "hold") || getcon("up", "hold")) cursorTimer--
@@ -95,7 +95,7 @@ const fontH = 14
 	if(getcon("jump", "press") || getcon("accept", "press")) {
 		if(menu[cursor].rawin("disabled")) return;
 		menu[cursor].func()
-		playSound(sndMenuSelect, 0)
+		soundPlay(sndMenuSelect, 0)
 	}
 
 	if(getcon("pause", "press")) {
@@ -168,7 +168,7 @@ const fontH = 14
 	},
 	{
 		name = function() { return gvLangObj["pause-menu"]["save"]},
-		func = function() { saveGame(); playSound(sndHeal, 0); gvGameMode = gmOverworld }
+		func = function() { saveGame(); soundPlay(sndHeal, 0); gvGameMode = gmOverworld }
 	},
 	{
 		name = function() { return gvLangObj["pause-menu"]["character"]},
@@ -190,6 +190,11 @@ const fontH = 14
 		name = function() { return gvLangObj["options-menu"]["joystick"] },
 		desc = function() { return gvLangObj["options-menu-desc"]["joystick"] },
 		func = function() { menu = meJoybinds }
+	},
+	{
+		name = function() { return gvLangObj["options-menu"]["audio"] },
+		desc = function() { return gvLangObj["options-menu-desc"]["audio"] },
+		func = function() { menu = meAudio }
 	},
 	{
 		name = function() {
@@ -381,6 +386,22 @@ const fontH = 14
 		name = function() { return gvLangObj["menu-commons"]["back"] },
 		func = function() { menu = meOptions }
 		back = function() { menu = meOptions }
+	}
+]
+
+::meAudio <- [
+	{
+		name = function() { return gvLangObj["audio-menu"]["sound"] + ": " + (config.soundenabled ? gvLangObj["bool"]["on"] : gvLangObj["bool"]["off"]) },
+		func = function() { config.soundenabled = !config.soundenabled }
+	},
+	{
+		name = function() { return gvLangObj["audio-menu"]["music"] + ": " + (config.musicenabled ? gvLangObj["bool"]["on"] : gvLangObj["bool"]["off"]) },
+		func = function() { config.musicenabled = !config.musicenabled; config.musicenabled ? songPlay(musTheme, true) : stopMusic() }
+	},
+	{
+		name = function() { return gvLangObj["menu-commons"]["back"] },
+		func = function() { cursor = 3; menu = meOptions }
+		back = function() { cursor = 3; menu = meOptions }
 	}
 ]
 

--- a/src/menus.nut
+++ b/src/menus.nut
@@ -157,7 +157,7 @@ const fontH = 14
 	}
 	{
 		name = function() { return gvLangObj["pause-menu"]["quit-level"]},
-		func = function() { startOverworld(game.world); cursor = 0 }
+		func = function() { startOverworld(game.world) }
 	}
 ]
 
@@ -176,7 +176,7 @@ const fontH = 14
 	},
 	{
 		name = function() { return gvLangObj["pause-menu"]["quit-game"]},
-		func = function() { saveGame(); startMain(); cursor = 0 }
+		func = function() { saveGame(); startMain() }
 	}
 ]
 
@@ -263,8 +263,8 @@ const fontH = 14
 	},
 	{
 		name = function() { return gvLangObj["menu-commons"]["back"] },
-		func = function() { cursor = 3; menu = meMain; fileWrite("config.json", jsonWrite(config)) }
-		back = function() { cursor = 3; menu = meMain; fileWrite("config.json", jsonWrite(config)) }
+		func = function() { menu = meMain; fileWrite("config.json", jsonWrite(config)) }
+		back = function() { menu = meMain; fileWrite("config.json", jsonWrite(config)) }
 	}
 
 ]
@@ -400,8 +400,8 @@ const fontH = 14
 	},
 	{
 		name = function() { return gvLangObj["menu-commons"]["back"] },
-		func = function() { cursor = 3; menu = meOptions }
-		back = function() { cursor = 3; menu = meOptions }
+		func = function() { menu = meOptions }
+		back = function() { menu = meOptions }
 	}
 ]
 
@@ -416,8 +416,8 @@ const fontH = 14
 	},
 	{
 		name = function() { return gvLangObj["menu-commons"]["back"] },
-		func = function() { cursor = 3; menu = meOptions }
-		back = function() { cursor = 3; menu = meOptions }
+		func = function() { menu = meOptions }
+		back = function() { menu = meOptions }
 	}
 ]
 
@@ -456,7 +456,6 @@ const fontH = 14
 			game.file = 0
 			if(fileExists("save/0.json")) menu = meOverwrite
 			else newGame(0)
-			cursor = 0
 		}
 	},
 	{
@@ -469,7 +468,6 @@ const fontH = 14
 			game.file = 1
 			if(fileExists("save/1.json")) menu = meOverwrite
 			else newGame(1)
-			cursor = 0
 		}
 	},
 	{
@@ -482,7 +480,6 @@ const fontH = 14
 			game.file = 2
 			if(fileExists("save/2.json")) menu = meOverwrite
 			else newGame(2)
-			cursor = 0
 		}
 	},
 	{
@@ -495,7 +492,6 @@ const fontH = 14
 			game.file = 3
 			if(fileExists("save/3.json")) menu = meOverwrite
 			else newGame(3)
-			cursor = 0
 		}
 	},
 	{
@@ -508,8 +504,8 @@ const fontH = 14
 ::meOverwrite <- [
 	{
 		name = function() { drawText(font2, screenW() / 2 - (15 * 4), screenH() / 2, "Overwrite save?"); return gvLangObj["menu-commons"]["no"] }
-		func = function() { menu = meNewGame; cursor = 0 }
-		back = function() { menu = meNewGame; cursor = 0 }
+		func = function() { menu = meNewGame; }
+		back = function() { menu = meNewGame; }
 	},
 	{
 		name = function() { return gvLangObj["menu-commons"]["yes"] }

--- a/src/platforms.nut
+++ b/src/platforms.nut
@@ -111,7 +111,7 @@
 						gvPlayer.hspeed = (gvPlayer.hspeed < -4) ? gvPlayer.hspeed : -power
 						break
 				}
-				if(frame == 0.0) playSound(sndSpring, 0)
+				if(frame == 0.0) soundPlay(sndSpring, 0)
 			}
 		}
 
@@ -185,7 +185,7 @@
 						gvPlayer.vspeed = -power * 0.8
 						break
 				}
-				if(frame == 0.0) playSound(sndSpring, 0)
+				if(frame == 0.0) soundPlay(sndSpring, 0)
 			}
 		}
 

--- a/src/shop.nut
+++ b/src/shop.nut
@@ -28,7 +28,7 @@
 			if(hitTest(shape, gvPlayer.shape)) if(gvPlayer.vspeed < 0 && v == 0) if(!soldout && game.coins >= price) {
 				gvPlayer.vspeed = 0
 				vspeed = -1
-				playSound(sndHeal, 0)
+				soundPlay(sndHeal, 0)
 				game.health += 4
 				game.maxHealth += 4
 				game.coins -= price
@@ -78,7 +78,7 @@
 			if(hitTest(shape, gvPlayer.shape)) if(gvPlayer.vspeed < 0 && v == 0) if(!soldout && game.coins >= price) {
 				gvPlayer.vspeed = 0
 				vspeed = -1
-				playSound(sndHeal, 0)
+				soundPlay(sndHeal, 0)
 				game.fireBonus += 1
 				game.coins -= price
 				if(game.weapon == 1) game.maxEnergy++
@@ -128,7 +128,7 @@
 			if(hitTest(shape, gvPlayer.shape)) if(gvPlayer.vspeed < 0 && v == 0) if(!soldout && game.coins >= price) {
 				gvPlayer.vspeed = 0
 				vspeed = -1
-				playSound(sndHeal, 0)
+				soundPlay(sndHeal, 0)
 				game.iceBonus += 1
 				game.coins -= price
 				if(game.weapon == 2) game.maxEnergy++
@@ -178,7 +178,7 @@
 			if(hitTest(shape, gvPlayer.shape)) if(gvPlayer.vspeed < 0 && v == 0) if(!soldout && game.coins >= price) {
 				gvPlayer.vspeed = 0
 				vspeed = -1
-				playSound(sndHeal, 0)
+				soundPlay(sndHeal, 0)
 				game.airBonus += 1
 				game.coins -= price
 				if(game.weapon == 3) game.maxEnergy++
@@ -228,7 +228,7 @@
 			if(hitTest(shape, gvPlayer.shape)) if(gvPlayer.vspeed < 0 && v == 0) if(!soldout && game.coins >= price) {
 				gvPlayer.vspeed = 0
 				vspeed = -1
-				playSound(sndHeal, 0)
+				soundPlay(sndHeal, 0)
 				game.earthBonus += 1
 				game.coins -= price
 				if(game.weapon == 4) game.maxEnergy++

--- a/src/tux.nut
+++ b/src/tux.nut
@@ -411,24 +411,24 @@
 						}
 						if(game.weapon != 3) {
 							stopSound(sndJump)
-							playSound(sndJump, 0)
+							soundPlay(sndJump, 0)
 						}
 						else {
 							stopSound(sndFlap)
-							playSound(sndFlap, 0)
+							soundPlay(sndFlap, 0)
 						}
 					}
 					else if(freeDown && anim != anClimb && !placeFree(x - 2, y) && anim != anWall && hspeed <= 0 && tileGetSolid(x - 12, y - 12) != 40 && tileGetSolid(x - 12, y + 12) != 40 && tileGetSolid(x - 12, y) != 40) {
 						flip = 0
 						anim = anWall
 						frame = anim[0]
-						playSound(sndWallkick, 0)
+						soundPlay(sndWallkick, 0)
 					}
 					else if(freeDown && anim != anClimb && !placeFree(x + 2, y) && anim != anWall && hspeed >= 0 && tileGetSolid(x + 12, y - 12) != 40 && tileGetSolid(x + 12, y + 12) != 40 && tileGetSolid(x + 12, y) != 40) {
 						flip = 1
 						anim = anWall
 						frame = anim[0]
-						playSound(sndWallkick, 0)
+						soundPlay(sndWallkick, 0)
 					}
 					else if(floor(energy) > 0 && game.weapon == 3 && getcon("jump", "press")) {
 						if(vspeed > 0) vspeed = 0.0
@@ -441,11 +441,11 @@
 						}
 						if(game.weapon != 3) {
 							stopSound(sndJump)
-							playSound(sndJump, 0)
+							soundPlay(sndJump, 0)
 						}
 						else {
 							stopSound(sndFlap)
-							playSound(sndFlap, 0)
+							soundPlay(sndFlap, 0)
 						}
 						energy--
 					}
@@ -488,14 +488,14 @@
 						frame = anim[0]
 						flip = 0
 						stopSound(sndSlide)
-						playSound(sndSlide, 0)
+						soundPlay(sndSlide, 0)
 					}
 					else if(placeFree(x - 2, y + 1) || hspeed <= -1.5) {
 						anim = anDive
 						frame = anim[0]
 						flip = 1
 						stopSound(sndSlide)
-						playSound(sndSlide, 0)
+						soundPlay(sndSlide, 0)
 					}
 					else {
 						anim = anDive
@@ -594,7 +594,7 @@
 						local c = actor[newActor(Fireball, x + fx, y - 4)]
 						if(!flip) c.hspeed = 5
 						else c.hspeed = -5
-						playSound(sndFireball, 0)
+						soundPlay(sndFireball, 0)
 						if(getcon("up", "hold")) {
 							c.vspeed = -2.5
 							c.hspeed /= 1.5
@@ -616,7 +616,7 @@
 						local c = actor[newActor(Iceball, x + fx, y - 4)]
 						if(!flip) c.hspeed = 5
 						else c.hspeed = -5
-						playSound(sndFireball, 0)
+						soundPlay(sndFireball, 0)
 						if(getcon("up", "hold")) {
 							c.vspeed = -2.5
 							c.hspeed /= 1.5
@@ -635,7 +635,7 @@
 					if(getcon("shoot", "press") && (anim == anJumpT || anim == anJumpU || anim == anFall) && anim != anHurt) {
 						anim = anDive
 						frame = anim[0]
-						playSound(sndSlide, 0)
+						soundPlay(sndSlide, 0)
 						if(flip == 0 && hspeed < 2) hspeed = 2
 						if(flip == 1 && hspeed > -2) hspeed = -2
 					}
@@ -645,7 +645,7 @@
 					if(getcon("shoot", "press") && (anim != anHurt)) {
 						anim = anDive
 						frame = anim[0]
-						playSound(sndSlide, 0)
+						soundPlay(sndSlide, 0)
 						if(flip == 0 && hspeed < 2) hspeed = 2
 						if(flip == 1 && hspeed > -2) hspeed = -2
 					}
@@ -746,7 +746,7 @@
 						local c = actor[newActor(Fireball, x + fx, y)]
 						if(!flip) c.hspeed = 3
 						else c.hspeed = -3
-						playSound(sndFireball, 0)
+						soundPlay(sndFireball, 0)
 						if(getcon("up", "hold")) {
 							c.vspeed = -3
 							if(hspeed != 0) c.hspeed *= 0.75
@@ -779,7 +779,7 @@
 						local c = actor[newActor(Iceball, x + fx, y)]
 						if(!flip) c.hspeed = 3
 						else c.hspeed = -3
-						playSound(sndFireball, 0)
+						soundPlay(sndFireball, 0)
 						if(getcon("up", "hold")) {
 							c.vspeed = -3
 							if(hspeed != 0) c.hspeed *= 0.75
@@ -877,7 +877,7 @@
 		if(hurt > 0 && invincible == 0) {
 			if(blinking == 0) {
 				blinking = 60
-				playSound(sndHurt, 0)
+				soundPlay(sndHurt, 0)
 				if(game.weapon == 4 && anim == anSlide && energy > 0) {
 					energy--
 					firetime = 120
@@ -1010,7 +1010,7 @@
 				game.maxEnergy++
 				game.subitem = 0
 				tftime = 0
-				playSound(sndHeal, 0)
+				soundPlay(sndHeal, 0)
 			}
 			return
 		}
@@ -1061,7 +1061,7 @@
 	constructor(_x, _y, _arr = null) {
 		base.constructor(_x, _y)
 		stopMusic()
-		playSound(sndDie, 0)
+		soundPlay(sndDie, 0)
 	}
 
 	function run() {

--- a/src/weapons.nut
+++ b/src/weapons.nut
@@ -167,7 +167,7 @@
 		base.constructor(_x, _y)
 
 		stopSound(sndExplodeF)
-		playSound(sndExplodeF, 0)
+		soundPlay(sndExplodeF, 0)
 
 		shape = Cir(x, y, 16)
 	}
@@ -200,7 +200,7 @@
 		base.constructor(_x, _y)
 
 		stopSound(sndBump)
-		playSound(sndBump, 0)
+		soundPlay(sndBump, 0)
 
 		shape = Rec(x, y, 16, 16, 0)
 	}
@@ -224,7 +224,7 @@
 		base.constructor(_x, _y)
 
 		stopSound(sndBump)
-		playSound(sndBump, 0)
+		soundPlay(sndBump, 0)
 
 		shape = Rec(x, y, 8, 8, 0)
 	}

--- a/tux.brx
+++ b/tux.brx
@@ -11,6 +11,7 @@
 \*===============================*/
 
 //Game source
+donut("src/audio.nut")
 donut("src/util.nut")
 donut("src/text.nut")
 donut("src/shapes.nut")


### PR DESCRIPTION
Allows toggling sound and music separately. Adds new `soundPlay`, `soundPlayChannel` and `musicPlay` functions, which do the same as `playSound`, `playSoundChannel` and `playMusic`, but check if the sound/music is enabled in the config beforehand.

This PR also fixes a menu cursor out-of-range error, which occurs on menus, that are smaller than the maximum menu display size. Removes unneeded changes to the `cursor` variable in menus, when some menu items are chosen.