### PR TITLE
Fix menu cursor out-of-range error

### DIFF
--- a/src/cursor.nut
+++ b/src/cursor.nut
@@ -22,7 +22,7 @@
 ::processCursorInput <- function() {
 	if(!config.showcursor) return; //If the cursor is disabled.
 
-	local pos = menuItemsPos[cursor - cursorOffset] //Get the position of the currently selected menu item only.
+	local pos = menuItemsPos[(menu.len() > menuMax ? cursor - cursorOffset : cursor)] //Get the position of the currently selected menu item only.
 	if(mouseX() >= pos.x - 3 && mouseX() <= pos.x + pos.len - 3 && mouseY() >= pos.y && mouseY() <= pos.y + fontH) {
 		if(menu[pos.index].rawin("disabled")) return;
 		menu[pos.index].func()

--- a/src/menus.nut
+++ b/src/menus.nut
@@ -172,7 +172,7 @@ const menuY = 40
 	},
 	{
 		name = function() { return gvLangObj["pause-menu"]["quit-level"]},
-		func = function() { startOverworld(game.world); cursor = 0 }
+		func = function() { startOverworld(game.world); }
 	}
 ]
 
@@ -195,7 +195,7 @@ const menuY = 40
 	},
 	{
 		name = function() { return gvLangObj["pause-menu"]["quit-game"]},
-		func = function() { saveGame(); startMain(); cursor = 0 }
+		func = function() { saveGame(); startMain(); }
 	}
 ]
 
@@ -476,8 +476,8 @@ const menuY = 40
 	},
 	{
 		name = function() { return gvLangObj["menu-commons"]["back"] },
-		func = function() { cursor = 3; menu = meOptions }
-		back = function() { cursor = 3; menu = meOptions }
+		func = function() { menu = meOptions }
+		back = function() { menu = meOptions }
 	}
 ]
 
@@ -516,7 +516,6 @@ const menuY = 40
 			game.file = 0
 			if(fileExists("save/0.json")) menu = meOverwrite
 			else newGame(0)
-			cursor = 0
 		}
 	},
 	{
@@ -529,7 +528,6 @@ const menuY = 40
 			game.file = 1
 			if(fileExists("save/1.json")) menu = meOverwrite
 			else newGame(1)
-			cursor = 0
 		}
 	},
 	{
@@ -542,7 +540,6 @@ const menuY = 40
 			game.file = 2
 			if(fileExists("save/2.json")) menu = meOverwrite
 			else newGame(2)
-			cursor = 0
 		}
 	},
 	{
@@ -555,7 +552,6 @@ const menuY = 40
 			game.file = 3
 			if(fileExists("save/3.json")) menu = meOverwrite
 			else newGame(3)
-			cursor = 0
 		}
 	},
 	{
@@ -568,8 +564,8 @@ const menuY = 40
 ::meOverwrite <- [
 	{
 		name = function() { drawText(font2, screenW() / 2 - (15 * 4), screenH() / 2, "Overwrite save?"); return gvLangObj["menu-commons"]["no"] }
-		func = function() { menu = meNewGame; cursor = 0 }
-		back = function() { menu = meNewGame; cursor = 0 }
+		func = function() { menu = meNewGame; }
+		back = function() { menu = meNewGame; }
 	},
 	{
 		name = function() { return gvLangObj["menu-commons"]["yes"] }


### PR DESCRIPTION
Fixes a menu cursor out-of-range error, which occurs on menus, that are smaller than the maximum menu display size. Previously mentioned in #79 and fixed in the Windows installer edition of Milestone 1 (0.1.0).

Additionally, this PR removes unneeded changes to the `cursor` variable in `menus.nut`.