### PR TITLE
Remember fullscreen preference

### DIFF
--- a/src/global.nut
+++ b/src/global.nut
@@ -124,6 +124,7 @@
 	usefilter = false
 	soundVolume = 128
 	musicVolume = 128
+	fullscreen = false
 }
 
 ::contribDidRun <- {}

--- a/src/menus.nut
+++ b/src/menus.nut
@@ -243,7 +243,7 @@ const menuY = 40
 	{
 		name = function() { return gvLangObj["options-menu"]["fullscreen"] },
 		desc = function() { return gvLangObj["options-menu-desc"]["fullscreen"] },
-		func = function() { toggleFullscreen() }
+		func = function() { toggleFullscreen(); config.fullscreen = !config.fullscreen }
 	},
 	{
 		name = function() {

--- a/tux.brx
+++ b/tux.brx
@@ -100,6 +100,7 @@ switch(reschoice) {
 
 gvTextW = floor(screenW() / 6) - 1
 
+if(config.fullscreen) toggleFullscreen()
 if(config.usefilter) setScalingFilter(1)
 gvScreen = newTexture(screenW(), screenH())
 bgPause = newTexture(screenW(), screenH())
@@ -137,7 +138,11 @@ config.playerChar = "Tux"
 
 while(!getQuit() && !gvQuit) //Entire game happens here
 {
-	if(keyPress(k_f11)) toggleFullscreen()
+	if(keyPress(k_f11)) {
+		toggleFullscreen()
+		config.fullscreen = !config.fullscreen
+		fileWrite("config.json", jsonWrite(config))
+	}
 	if(getcon("pause", "press") && levelEndRunner == 0 && gvGameMode != gmMain) togglePause()
 	gvGameMode()
 	if(keyPress(k_tick)) debugConsole()


### PR DESCRIPTION
Adds a `fullscreen` property to the config, allows the toggle fullscreen features (both the one from "Options" and "F11") to change that property and makes the game check if it's set to `true` on game startup, and if so, execute `toggleFullscreen()`.