### PR TITLE
Progress counter for contrib levels

### DIFF
--- a/src/contriblevels.nut
+++ b/src/contriblevels.nut
@@ -1,7 +1,7 @@
 ::meContribLevels <- [
 
 ]
-::lastLevelsCounted <- {"contribFolder":null, "completed":null, "total":null}
+::lastLevelsCounted <- {"contribFolder":null, "completed":null, "total":null, "percentage":null}
 
 ::selectContrib <- function(){
 	meContribLevels = []
@@ -17,7 +17,7 @@
 						contribWorldmap = data["worldmap"]
 						name = function() { return contribName }
 						func = function() {
-							lastLevelsCounted = {"contribFolder":null, "completed":null, "total":null}
+							lastLevelsCounted = {"contribFolder":null, "completed":null, "total":null, "percentage":null}
 							game=clone(gameDefault)
 							game.completed.clear()
 							game.allCoins.clear()
@@ -47,7 +47,7 @@
 						desc = function() {
 							if(lastLevelsCounted["contribFolder"] == contribFolder) {
 								//Check if the same world as last frame is selected and if so, return saved data.
-								return "Progress: " + lastLevelsCounted["completed"] + "/" + lastLevelsCounted["total"]
+								return "Progress: " + lastLevelsCounted["completed"] + "/" + lastLevelsCounted["total"] + " (" + lastLevelsCounted["percentage"] + "%)"
 							}
 
 							local levels = []
@@ -71,8 +71,10 @@
 								}
 							}
 
-							lastLevelsCounted = {"contribFolder":contribFolder, "completed":completedLevelsCount, "total":levels.len()}
-							return "Progress: " + completedLevelsCount + "/" + levels.len()
+							local percentage = completedLevelsCount * 100 / levels.len()
+
+							lastLevelsCounted = {"contribFolder":contribFolder, "completed":completedLevelsCount, "total":levels.len(), "percentage":percentage}
+							return "Progress: " + completedLevelsCount + "/" + levels.len() + " (" + percentage + "%)"
 						}
 					}
 				)

--- a/src/contriblevels.nut
+++ b/src/contriblevels.nut
@@ -42,6 +42,30 @@
 							if(fileExists("save/" + contribFolder + ".json")) loadGame(contribFolder)
 							else startOverworld("contrib/" + contribFolder + "/" + contribWorldmap)
 						}
+						desc = function() {
+							local levels = []
+							local completedLevelsCount = 0
+
+							//Get all levels
+							local contribWorldmapData = jsonRead(fileRead("contrib/" + contribFolder + "/" + contribWorldmap))
+							foreach(layer in contribWorldmapData["layers"]) {
+								if(!layer.rawin("objects")) continue
+								foreach(obj in layer["objects"]) {
+									if(!obj.rawin("gid")) continue
+									if(obj["gid"] == 842 && obj["visible"]) levels.push(obj["name"])
+								}
+							}
+
+							//Get completed levels count
+							if(fileExists("save/" + contribFolder + ".json")) {
+								local contribWorldmapSaveData = jsonRead(fileRead("save/" + contribFolder + ".json"))
+								foreach(level, levelCompleted in contribWorldmapSaveData["completed"]) {
+									if(levelCompleted && levels.find(level)) completedLevelsCount++
+								}
+							}
+
+							return "Progress: " + completedLevelsCount + "/" + levels.len()
+						}
 					}
 				)
 			}

--- a/src/contriblevels.nut
+++ b/src/contriblevels.nut
@@ -1,6 +1,7 @@
 ::meContribLevels <- [
 
 ]
+::lastLevelsCounted <- {"contribFolder":null, "completed":null, "total":null}
 
 ::selectContrib <- function(){
 	meContribLevels = []
@@ -16,6 +17,7 @@
 						contribWorldmap = data["worldmap"]
 						name = function() { return contribName }
 						func = function() {
+							lastLevelsCounted = {"contribFolder":null, "completed":null, "total":null}
 							game=clone(gameDefault)
 							game.completed.clear()
 							game.allCoins.clear()
@@ -43,6 +45,11 @@
 							else startOverworld("contrib/" + contribFolder + "/" + contribWorldmap)
 						}
 						desc = function() {
+							if(lastLevelsCounted["contribFolder"] == contribFolder) {
+								//Check if the same world as last frame is selected and if so, return saved data.
+								return "Progress: " + lastLevelsCounted["completed"] + "/" + lastLevelsCounted["total"]
+							}
+
 							local levels = []
 							local completedLevelsCount = 0
 
@@ -60,10 +67,11 @@
 							if(fileExists("save/" + contribFolder + ".json")) {
 								local contribWorldmapSaveData = jsonRead(fileRead("save/" + contribFolder + ".json"))
 								foreach(level, levelCompleted in contribWorldmapSaveData["completed"]) {
-									if(levelCompleted && levels.find(level)) completedLevelsCount++
+									if(levelCompleted && levels.find(level) != null) completedLevelsCount++
 								}
 							}
 
+							lastLevelsCounted = {"contribFolder":contribFolder, "completed":completedLevelsCount, "total":levels.len()}
 							return "Progress: " + completedLevelsCount + "/" + levels.len()
 						}
 					}


### PR DESCRIPTION
When the user hovers over a contrib world, the description shows the level progress there, in the format:

**Progress: [`completed`/`total`]**

Completed levels are counted based on the save file for that contrib world (if it exists), and the total amount - from counting all objects in its worldmap and checking if they match the `gid` of `842` (are level objects) and are visible.