### PR TITLE
Update the way game object is cleared

### DIFF
--- a/src/contriblevels.nut
+++ b/src/contriblevels.nut
@@ -18,12 +18,7 @@
 						name = function() { return contribName }
 						func = function() {
 							lastLevelsCounted = {"contribFolder":null, "completed":null, "total":null, "percentage":null}
-							game=clone(gameDefault)
-							game.completed.clear()
-							game.allCoins.clear()
-							game.allEnemies.clear()
-							game.allSecrets.clear()
-							game.bestTime.clear()
+							game=createNewGameObject()
 							game.file = contribFolder
 							game.path = "contrib/" + contribFolder + "/"
 							game.world = contribWorldmap

--- a/src/global.nut
+++ b/src/global.nut
@@ -6,71 +6,75 @@
 ::gvMap <- 0
 ::gvGameMode <- 0
 ::gvQuit <- false
-::game <- { //Globals stored in this table will be saved
-	difficulty = 0
-	file = 0
-	coins = 0
-	levelCoins = 0
-	maxCoins = 0 //Total coins in the level
-	redcoins = 0
-	levelredcoins = 0
-	maxredcoins = 0
-	secrets = 0
-	enemies = 0
-	health = 12
-	maxHealth = 12
-	weapon = 0
-	maxEnergy = 0
-	fireBonus = 0
-	iceBonus = 0
-	airBonus = 0
-	earthBonus = 0
-	subitem = 0
-	completed = {} //List of completed level names
-	allCoins = {} //Levels that the player has gotten all enemies in
-	allEnemies = {} //Levels that the player has beaten all enemies in
-	allSecrets = {} //Levels the player has found all secrets in
-	bestTime = {} //Fastest time for a level
-	igt = 0 //Global IGT, which increments throughout the game's runtime
-	colorswitch = [
-		false,
-		false,
-		false,
-		false,
-		false,
-		false,
-		false,
-		false
-	] //Color blocks activated by respective switches
-	characters = { //List of unlocked characters
-		Tux = ["sprTuxOverworld", "sprTuxDoll", "sprTux", [40, 41]]
-		//Konqi = ["sprKonqiOverworld", "sprKonqiDoll", "sprKonqi", [8, 9]]
+
+::createNewGameObject <- function () {
+	return { //Globals stored in this table will be saved
+		difficulty = 0
+		file = 0
+		coins = 0
+		levelCoins = 0
+		maxCoins = 0 //Total coins in the level
+		redcoins = 0
+		levelredcoins = 0
+		maxredcoins = 0
+		secrets = 0
+		enemies = 0
+		health = 12
+		maxHealth = 12
+		weapon = 0
+		maxEnergy = 0
+		fireBonus = 0
+		iceBonus = 0
+		airBonus = 0
+		earthBonus = 0
+		subitem = 0
+		completed = {} //List of completed level names
+		allCoins = {} //Levels that the player has gotten all enemies in
+		allEnemies = {} //Levels that the player has beaten all enemies in
+		allSecrets = {} //Levels the player has found all secrets in
+		bestTime = {} //Fastest time for a level
+		igt = 0 //Global IGT, which increments throughout the game's runtime
+		colorswitch = [
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			false
+		] //Color blocks activated by respective switches
+		characters = { //List of unlocked characters
+			Tux = ["sprTuxOverworld", "sprTuxDoll", "sprTux", [40, 41]]
+			//Konqi = ["sprKonqiOverworld", "sprKonqiDoll", "sprKonqi", [8, 9]]
+		}
+		secretOrbs = [
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			false
+		]
+		friends = {} //List of rescued friend characters
+		playerChar = "Tux" //Current player character
+		world = "res/map/overworld-0.json"
+		owx = 0
+		owy = 0
+		owd = 0
+		check = false //If a checkpoint has been activated
+		chx = 0
+		chy = 0
+		berries = 0
+		path = "res/map/"
+		canres = false //If the player can respawn
+		bossHealth = 0
 	}
-	secretOrbs = [
-		false,
-		false,
-		false,
-		false,
-		false,
-		false,
-		false,
-		false
-	]
-	friends = {} //List of rescued friend characters
-	playerChar = "Tux" //Current player character
-	world = "res/map/overworld-0.json"
-	owx = 0
-	owy = 0
-	owd = 0
-	check = false //If a checkpoint has been activated
-	chx = 0
-	chy = 0
-	berries = 0
-	path = "res/map/"
-	canres = false //If the player can respawn
-	bossHealth = 0
 }
-::gameDefault <- clone(game)
+
+::game <- createNewGameObject()
 ::gvPlayer <- false; //Pointer to player actor
 ::gvBoss <- false; //Pointer to boss actor
 /*\

--- a/src/gmmain.nut
+++ b/src/gmmain.nut
@@ -1,7 +1,7 @@
 ::startMain <- function() {
 	stopMusic()
 	songPlay(musTheme)
-	game = clone(gameDefault)
+	game = createNewGameObject()
 	drawBG = dbgUnderwater
 	gvGameMode = gmMain
 	actor = {}

--- a/src/save.nut
+++ b/src/save.nut
@@ -1,11 +1,6 @@
 ::newGame <- function(f) {
 	local newdif = game.difficulty
-	game = clone(gameDefault)
-	game.completed.clear()
-	game.allCoins.clear()
-	game.allEnemies.clear()
-	game.allSecrets.clear()
-	game.bestTime.clear()
+	game = createNewGameObject()
 	game.file = f
 	gvDoIGT = false
 	game.difficulty = newdif
@@ -19,7 +14,7 @@
 
 ::loadGame <- function(f) {
 	if(fileExists("save/" + f.tostring() + ".json")) {
-		game = mergeTable(gameDefault, jsonRead(fileRead("save/" + f.tostring() + ".json")))
+		game = mergeTable(createNewGameObject(), jsonRead(fileRead("save/" + f.tostring() + ".json")))
 		startOverworld(game.world)
 	}
 }


### PR DESCRIPTION
This fixes a few issues where previous game data can persist even when starting a new file.

For instance, if Konqi has been freed, then Konqi will remain freed even if the player starts a new save file (to reproduce: start STA, then enter the "extra levels" contrib world, notice that "extra levels" automatically frees Konqi, then quit back to the main menu, then start a new save file, and observe that Konqi is selectable as a playable character).

Similarly, other data stored in arrays/objects is also not cleared -- for instance, if the player has hit the red switch, the red switch remains activated even if a new save file is started.