### PR TITLE
Update the way pickchar works

### DIFF
--- a/src/menus.nut
+++ b/src/menus.nut
@@ -187,7 +187,7 @@ const menuY = 40
 	},
 	{
 		name = function() { return gvLangObj["pause-menu"]["character"]},
-		func = function() { pickChar() }
+		func = function() { pickCharInitialize(); gvGameMode = pickChar }
 	},
 	{
 		name = function() { return gvLangObj["main-menu"]["options"] },

--- a/src/pickchar.nut
+++ b/src/pickchar.nut
@@ -1,66 +1,80 @@
-::pickChar <- function() {
-	update()
-	resetDrawTarget()
 
+::pickCharSettings <- {}
+
+::pickCharInitialize <- function() {
 	//Make ordered list of characters
-	local charlist = []
+	pickCharSettings.charlist <- []
 	foreach(key, i in game.characters) {
 		local newitem = [key, i[2], i[3]]
-		charlist.push(newitem)
+		pickCharSettings.charlist.push(newitem)
 	}
 
 	//Sort characters
 	//Squirrel tables are sorted by hash, so the list will appear
 	//randomized if this is not done
-	charlist.sort(function(a, b) {
+	pickCharSettings.charlist.sort(function(a, b) {
 		if(a[0] > b[0]) return 1
 		if(a[0] < b[0]) return -1
 		return 0
 	})
-
-	local didpick = false
-	local picktimer = 30
-	local charslot = 0
-
+	
+	pickCharSettings.didpick <- false
+	pickCharSettings.picktimer <- 30
+	pickCharSettings.charslot <- 0
+	
 	//Set cursor to current character
-	for(local i = 0; i < charlist.len(); i++) {
-		if(charlist[i][0] == game.playerChar) {
-			charslot = i
+	for(local i = 0; i < pickCharSettings.charlist.len(); i++) {
+		if(pickCharSettings.charlist[i][0] == game.playerChar) {
+			pickCharSettings.charslot = i
 			break
 		}
 	}
+}
 
-	//Function loop
-	while(!getcon("pause", "press") && picktimer > 0) {
-		setDrawTarget(gvScreen)
-		drawSprite(bgCharSel, 0, screenW() / 2, 0)
+::pickChar <- function() {
 
-		if(!didpick) {
-			//Move selection
-			if(getcon("right", "press")) charslot++
-			if(getcon("left", "press")) charslot--
-			if(charslot < 0) charslot = charlist.len() - 1
-			if(charslot >= charlist.len()) charslot = 0
-
-			if(getcon("accept", "press") || getcon("jump", "press")) {
-				game.playerChar = charlist[charslot][0]
-				didpick = true
-			}
-		}
-		else {
-			picktimer--
-		}
-
-		//Draw
-		drawText(font2, (screenW() / 2) - (gvLangObj["options-menu"]["charsel"].len() * 4), 64, gvLangObj["options-menu"]["charsel"])
-		drawText(font2, (screenW() / 2) - (charlist[charslot][0].len() * 4), 80, charlist[charslot][0])
-		if(didpick) drawSprite(getroottable()[charlist[charslot][1]], charlist[charslot][2][1], screenW() / 2, screenH() - 64)
-		else drawSprite(getroottable()[charlist[charslot][1]], charlist[charslot][2][0], screenW() / 2, screenH() - 64)
-
-		resetDrawTarget()
-		drawImage(gvScreen, 0, 0)
-		update()
+	local didpick = pickCharSettings.didpick
+	local charslot = pickCharSettings.charslot
+	local charlist = pickCharSettings.charlist
+	local picktimer = pickCharSettings.picktimer
+	
+	if (getcon("pause", "press") || picktimer <= 0) {
+		gvGameMode = gmOverworld
+		return
 	}
+
+	setDrawTarget(gvScreen)
+	drawSprite(bgCharSel, 0, screenW() / 2, 0)
+	
+	if(!didpick) {
+		//Move selection
+		if(getcon("right", "press")) charslot++
+		if(getcon("left", "press")) charslot--
+		if(charslot < 0) charslot = charlist.len() - 1
+		if(charslot >= charlist.len()) charslot = 0
+
+		if(getcon("accept", "press") || getcon("jump", "press")) {
+			game.playerChar = charlist[charslot][0]
+			didpick = true
+		}
+	}
+	else {
+		picktimer--
+	}
+
+	//Draw
+	drawText(font2, (screenW() / 2) - (gvLangObj["options-menu"]["charsel"].len() * 4), 64, gvLangObj["options-menu"]["charsel"])
+	drawText(font2, (screenW() / 2) - (charlist[charslot][0].len() * 4), 80, charlist[charslot][0])
+	if(didpick) drawSprite(getroottable()[charlist[charslot][1]], charlist[charslot][2][1], screenW() / 2, screenH() - 64)
+	else drawSprite(getroottable()[charlist[charslot][1]], charlist[charslot][2][0], screenW() / 2, screenH() - 64)
+
+	resetDrawTarget()
+	drawImage(gvScreen, 0, 0)
+	
+	pickCharSettings.didpick = didpick
+	pickCharSettings.charslot = charslot
+	pickCharSettings.charlist = charlist
+	pickCharSettings.picktimer = picktimer
 }
 
 ::addChar <- function(char, overworld, doll, playable, frames) {


### PR DESCRIPTION
I propose this slight change to how the `pickchar` function works. (`pickchar` is responsible for allowing the player to pick between Tux and Konqi.)

Currently, `pickchar` is the only place in the codebase that runs its own game loop -- this is the loop on [line 34](https://github.com/KelvinShadewing/supertux-advance/blob/a7bf3e646bdd185a3dbef47ecac549dda4765cfc/src/pickchar.nut#L34) which includes its own invocation of `update()`. All other places in the codebase use the main game loop, defined on [line 139 in `Tux.brx`](https://github.com/KelvinShadewing/supertux-advance/blob/a7bf3e646bdd185a3dbef47ecac549dda4765cfc/tux.brx#L139).

This has several minor issues:
* The exit button (to close the program) doesn't work when selecting a character. This occurs because `pickchar`'s game loop doesn't include the `!getQuit() && !gvQuit` check that the main game loop uses.
* The tilde button to activate the debugConsole doesn't work when selecting a character (because the line `if(keyPress(k_tick)) debugConsole()` is also not present)
* F11 doesn't change to/from full-screen when selecting a character (because the `keyPress(k_f11)` check is not present).

`pickchar`'s game loop could be updated but I figured it might be easier to just defer to the main game loop. That way there isn't any duplicate code.