### PR TITLE
Bugfix: Remove player2Char from src/global.nut

### DIFF
--- a/src/global.nut
+++ b/src/global.nut
@@ -84,7 +84,6 @@
 		levelEvents = {} //Events that have occured in individual levels
 		friends = {} //List of rescued friend characters
 		playerChar = "Tux" //Current player character
-		player2Char = null
 		world = "res/map/overworld-0.json"
 		owx = 0
 		owy = 0


### PR DESCRIPTION
**If you save your game and load it, it will not load correctly.**
And if you look at the json file, you will see this in the save file:
```json
"player2Char":(null : 0x(nil))
```
That's obviously not valid JSON, which is what's causing it to fail to load the save file and overwrite it with a new save file.
The core problem is that the JSON implementation is not correctly saving null values.

This PR removes `player2Char` from src/global.nut to prevent it from saving that null value, which will cause it to save and load correctly.

**(The real solution for this would be fixing the json implementation, but that would be much harder to do than just removing the null value)**

...I have no idea how this bug got into the final release of 0.2.x (since the bug is very noticeable), but it did.