### PR TITLE
Bring over PhysicsFS support to SuperTux Advance

### DIFF
--- a/game.brx
+++ b/game.brx
@@ -10,7 +10,7 @@
 |                                 |
 \*===============================*/
 
-setWriteDir(getPrefDir("SuperTuxAdvance", "supertux-advance"))
+setWriteDir(getPrefDir("sta", "supertux-advance"))
 
 //Game source
 donut("src/util.nut")

--- a/game.brx
+++ b/game.brx
@@ -10,6 +10,8 @@
 |                                 |
 \*===============================*/
 
+setWriteDir(getPrefDir("SuperTuxAdvance", "supertux-advance"))
+
 //Game source
 donut("src/util.nut")
 donut("src/text.nut")

--- a/save/delete.me
+++ b/save/delete.me
@@ -1,1 +1,0 @@
-This file is just so Git preserves this folder. You don't need it.


### PR DESCRIPTION
NOTE: DEPENDS ON [BRUX PR 47](https://github.com/KelvinShadewing/brux-gdk/pull/47).

This PR adds a line that causes STA's file writing calls to go to a specific directory.

Directory examples:
- Windows - $HOME/AppData/sta/supertux-advance
- Linux - $HOME/.local/share/supertux-advance

Changes:
- Remove saves folder (PhysicsFS will now create it automatically)
- One line of code that changes the write dir.