### PR TITLE
Three digit milliseconds in timers

### DIFF
--- a/src/text.nut
+++ b/src/text.nut
@@ -66,3 +66,4 @@
 		local seconds_p2 = (seconds - floor(seconds)) * 1000
 		return format("%02d:%02d.%03d", minutes, seconds_p1, seconds_p2);
 	}
+#

--- a/src/text.nut
+++ b/src/text.nut
@@ -1,75 +1,68 @@
-::textLineLen <- function(_s, _l) {
-	_s = strip(_s)
-	if(_s.len() == 0) return
+::textLineLen <-  function(_s, _l) {
+		_s = strip(_s)
+		if (_s.len() == 0) return
 
-	local newstr = "" //New string being made
-	local curline = ""
-	local words = split(_s, " ")
+		local newstr = "" //New string being made
+		local curline = ""
+		local words = split(_s, " ")
 
-	foreach(i in words) {
-		if(i.len() >= _l) {
-			newstr += i
-			newstr += "\n"
-			curline = ""
-		}
-		else {
-			if(curline.len() + i.len() + 1 >= _l) {
-				newstr += curline
-				curline = ""
+		foreach(i in words) {
+			if (i.len() >= _l) {
+				newstr += i
 				newstr += "\n"
-			}
-			if(curline.len() + i.len() + 1 <= _l) {
-				curline += i
-				curline += " "
+				curline = ""
+			} else {
+				if (curline.len() + i.len() + 1 >= _l) {
+					newstr += curline
+					curline = ""
+					newstr += "\n"
+				}
+				if (curline.len() + i.len() + 1 <= _l) {
+					curline += i
+					curline += " "
+				}
 			}
 		}
+
+		newstr += curline
+
+		return newstr
 	}
 
-	newstr += curline
+	::drawTextLen <-  function(_f, _x, _y, _s, _l) {
+		_s = strip(_s)
+		if (_s.len() == 0) return
 
-	return newstr
-}
+		local newstr = "" //New string being made
+		local curline = ""
+		local words = split(_s, " ")
 
-::drawTextLen <- function(_f, _x, _y, _s, _l) {
-	_s = strip(_s)
-	if(_s.len() == 0) return
-
-	local newstr = "" //New string being made
-	local curline = ""
-	local words = split(_s, " ")
-
-	foreach(i in words) {
-		if(i.len() >= _l) {
-			newstr += i
-			newstr += "\n"
-			curline = ""
-		}
-		else {
-			if(curline.len() + i.len() + 1 < _l) {
-				curline += i
-				curline += " "
-			}
-			if(curline.len() + i.len() + 1 >= _l) {
-				newstr += curline
-				curline = ""
+		foreach(i in words) {
+			if (i.len() >= _l) {
+				newstr += i
 				newstr += "\n"
+				curline = ""
+			} else {
+				if (curline.len() + i.len() + 1 < _l) {
+					curline += i
+					curline += " "
+				}
+				if (curline.len() + i.len() + 1 >= _l) {
+					newstr += curline
+					curline = ""
+					newstr += "\n"
+				}
 			}
 		}
+
+		drawText(_f, _x, _y, newstr)
 	}
 
-	drawText(_f, _x, _y, newstr)
-}
+	::formatTime <-  function(time) {
+		local seconds = (time % 3600).tofloat() / 60.0
+		local minutes = floor(time / 3600)
 
-::formatTime <- function(time) {
-	local seconds = (time % 3600).tofloat() / 60.0
-	seconds *= 100.0
-	seconds = floor(seconds).tofloat()
-	seconds /= 100
-	local minutes = floor(time / 3600)
-	local val = minutes.tostring() + ":"
-	if(seconds < 10) val += "0"
-	val += seconds.tostring()
-	if(seconds == floor(seconds)) val += ".00"
-	if(seconds * 10 == floor(seconds * 10) && (seconds * 100) % 100 != 0) val += "0"
-	return val
-}
+		local seconds_p1 = ceil(seconds)
+		local seconds_p2 = (seconds - floor(seconds)) * 1000
+		return format("%02d:%02d.%03d", minutes, seconds_p1, seconds_p2);
+	}


### PR DESCRIPTION
speedrun.com leaderboards require milliseconds in submitted times to be three digits instead of two. If your time has two digit milliseconds, you are expected to add a zero before it, but it'd be better if the missing data was actually shown. This PR into the `unstable` branch does that; actually, it rewrites the whole function and uses squirrel's format function instead of manually formatting it.

Also, apparently whatever formatter I got with VSCode really insists on indenting this entire file further. I can try and fix this if this is an issue.