### PR TITLE
The block sprites in the overworld are wrong

### DIFF
--- a/src/overworld.nut
+++ b/src/overworld.nut
@@ -239,10 +239,12 @@
 			}
 
 			local blockx = gvScreenW - 21
+			local blocky = gvScreenH - 21
 			for(local i = 7; i >= 0; i--) {
 				if(game.colorswitch[i]) {
-					drawSprite(sprColorBlock, ((i * 2) + 1) + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-					blockx -= 16
+					drawSprite(sprColorBlock, ((i * 2) + 1) + int(game.turnOffBlocks), blockx, blocky)
+					blockx -= 4
+					blocky -= 4
 				}
 			}
 		}

--- a/src/overworld.nut
+++ b/src/overworld.nut
@@ -239,37 +239,11 @@
 			}
 
 			local blockx = gvScreenW - 21
-			if(game.colorswitch[7]) {
-				drawSprite(sprColorBlock, 14 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
-			}
-			if(game.colorswitch[6]) {
-				drawSprite(sprColorBlock, 13 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
-			}
-			if(game.colorswitch[5]) {
-				drawSprite(sprColorBlock, 11 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
-			}
-			if(game.colorswitch[4]) {
-				drawSprite(sprColorBlock, 9 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
-			}
-			if(game.colorswitch[3]) {
-				drawSprite(sprColorBlock, 7 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
-			}
-			if(game.colorswitch[2]) {
-				drawSprite(sprColorBlock, 5 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
-			}
-			if(game.colorswitch[1]) {
-				drawSprite(sprColorBlock, 3 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
-			}
-			if(game.colorswitch[0]) {
-				drawSprite(sprColorBlock, 1 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
+			for(local i = 7; i >= 0; i--) {
+				if(game.colorswitch[i]) {
+					drawSprite(sprColorBlock, ((i * 2) + 1) + int(game.turnOffBlocks), blockx, gvScreenH - 21)
+					blockx -= 16
+				}
 			}
 		}
 		

--- a/src/overworld.nut
+++ b/src/overworld.nut
@@ -40,48 +40,6 @@
 		&& !getcon("down", "hold", true, 0))
 			canmove = true
 
-		if (game.colorswitch.find(true) != null) {
-			if(getcon("spec1", "press")) {
-				game.turnOffBlocks = !game.turnOffBlocks
-				playSound(sndMenuSelect, 0)
-			}
-
-			local blockx = gvScreenW - 21
-			if(game.colorswitch[7]) {
-				drawSprite(sprColorBlock, 14 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
-			}
-			if(game.colorswitch[6]) {
-				drawSprite(sprColorBlock, 12 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
-			}
-			if(game.colorswitch[5]) {
-				drawSprite(sprColorBlock, 10 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
-			}
-			if(game.colorswitch[4]) {
-				drawSprite(sprColorBlock, 8 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
-			}
-			if(game.colorswitch[3]) {
-				drawSprite(sprColorBlock, 6 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
-			}
-			if(game.colorswitch[2]) {
-				drawSprite(sprColorBlock, 4 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
-			}
-			if(game.colorswitch[1]) {
-				drawSprite(sprColorBlock, 2 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
-			}
-			if(game.colorswitch[0]) {
-				drawSprite(sprColorBlock, 0 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
-				blockx -= 16
-			}
-			
-		}
-
 		local level = ""
 		local onstage = false
 		local noclear = false
@@ -274,7 +232,47 @@
 
 		if(hspeed == 0 && vspeed == 0) drawSpriteZ(2, getroottable()[gvCharacters[game.playerChar]["over"]], 0, x - camx, y - camy)
 		else drawSpriteZ(2, getroottable()[gvCharacters[game.playerChar]["over"]], getFrames() / 8, x - camx, y - camy)
+		if (game.colorswitch.find(true) != null) {
+			if(getcon("spec1", "press")) {
+				game.turnOffBlocks = !game.turnOffBlocks
+				playSound(sndMenuSelect, 0)
+			}
 
+			local blockx = gvScreenW - 21
+			if(game.colorswitch[7]) {
+				drawSprite(sprColorBlock, 14 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
+				blockx -= 16
+			}
+			if(game.colorswitch[6]) {
+				drawSprite(sprColorBlock, 13 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
+				blockx -= 16
+			}
+			if(game.colorswitch[5]) {
+				drawSprite(sprColorBlock, 11 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
+				blockx -= 16
+			}
+			if(game.colorswitch[4]) {
+				drawSprite(sprColorBlock, 9 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
+				blockx -= 16
+			}
+			if(game.colorswitch[3]) {
+				drawSprite(sprColorBlock, 7 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
+				blockx -= 16
+			}
+			if(game.colorswitch[2]) {
+				drawSprite(sprColorBlock, 5 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
+				blockx -= 16
+			}
+			if(game.colorswitch[1]) {
+				drawSprite(sprColorBlock, 3 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
+				blockx -= 16
+			}
+			if(game.colorswitch[0]) {
+				drawSprite(sprColorBlock, 1 + int(game.turnOffBlocks), blockx, gvScreenH - 21)
+				blockx -= 16
+			}
+		}
+		
 		gvLevel = level
 	}
 


### PR DESCRIPTION
The outline is shown when they're enabled and the filled sprite is shown when they're disabled. You need to add 1 to all the values you set in that part of the code.

This fixes that.

It also moves the block of code to end of the main function, in order to have it be drawn over everything else.

As shown below, I also changed the position of the blocks so that the UI looks a bit cleaner.