### PR TITLE
Fix an out of bounds crash in the buttons menu.

### DIFF
--- a/src/controls.nut
+++ b/src/controls.nut
@@ -634,68 +634,134 @@
 		case "jump":
 			if(getkey)
 				output += gvLangObj["key"][config.key.jump.tostring()]
-			if(getjoy)
-				output += gvLangObj["joy"][config["joymode"].tolower()][config.joy.jump.tostring()]
+			if(getjoy) {
+				local map = gvLangObj["joy"][config["joymode"].tolower()]
+				if(config.joy.jump.tostring() in map) {
+					output += map[config.joy.jump.tostring()]
+				} else {
+					output += "???"
+				}
+			}
 			break
 		case "shoot":
 			if(getkey)
 				output += gvLangObj["key"][config.key.shoot.tostring()]
-			if(getjoy)
-				output += gvLangObj["joy"][config["joymode"].tolower()][config.joy.shoot.tostring()]
+			if(getjoy) {
+				local map = gvLangObj["joy"][config["joymode"].tolower()]
+				if(config.joy.shoot.tostring() in map) {
+					output += map[config.joy.shoot.tostring()]
+				} else {
+					output += "???"
+				}
+			}
 			break
 		case "spec1":
 			if(getkey)
 				output += gvLangObj["key"][config.key.spec1.tostring()]
-			if(getjoy)
-				output += gvLangObj["joy"][config["joymode"].tolower()][config.joy.spec1.tostring()]
+			if(getjoy) {
+				local map = gvLangObj["joy"][config["joymode"].tolower()]
+				if(config.joy.spec1.tostring() in map) {
+					output += map[config.joy.spec1.tostring()]
+				} else {
+					output += "???"
+				}
+			}
 			break
 		case "spec2":
 			if(getkey)
 				output += gvLangObj["key"][config.key.spec2.tostring()]
-			if(getjoy)
-				output += gvLangObj["joy"][config["joymode"].tolower()][config.joy.spec2.tostring()]
+			if(getjoy) {
+				local map = gvLangObj["joy"][config["joymode"].tolower()]
+				if(config.joy.spec2.tostring() in map) {
+					output += map[config.joy.spec2.tostring()]
+				} else {
+					output += "???"
+				}
+			}
 			break
 		case "swap":
 			if(getkey)
 				output += gvLangObj["key"][config.key.swap.tostring()]
-			if(getjoy)
-				output += gvLangObj["joy"][config["joymode"].tolower()][config.joy.swap.tostring()]
+						if(getjoy) {
+				local map = gvLangObj["joy"][config["joymode"].tolower()]
+				if(config.joy.swap.tostring() in map) {
+					output += map[config.joy.swap.tostring()]
+				} else {
+					output += "???"
+				}
+			}
 			break
 		case "pause":
 			if(getkey)
 				output += gvLangObj["key"][config.key.pause.tostring()]
-			if(getjoy)
-				output += gvLangObj["joy"][config["joymode"].tolower()][config.joy.pause.tostring()]
+						if(getjoy) {
+				local map = gvLangObj["joy"][config["joymode"].tolower()]
+				if(config.joy.pause.tostring() in map) {
+					output += map[config.joy.pause.tostring()]
+				} else {
+					output += "???"
+				}
+			}
 			break
 		case "accept":
 			if(getkey)
 				output += gvLangObj["key"][config.key.accept.tostring()]
-			if(getjoy)
-				output += gvLangObj["joy"][config["joymode"].tolower()][config.joy.accept.tostring()]
+						if(getjoy) {
+				local map = gvLangObj["joy"][config["joymode"].tolower()]
+				if(config.joy.accept.tostring() in map) {
+					output += map[config.joy.accept.tostring()]
+				} else {
+					output += "???"
+				}
+			}
 			break
 		case "leftPeek":
 			if(getkey)
 				output += gvLangObj["key"][config.key.leftPeek.tostring()]
-			if(getjoy)
-				output += gvLangObj["joy"][config["joymode"].tolower()][config.joy.leftPeek.tostring()]
+						if(getjoy) {
+				local map = gvLangObj["joy"][config["joymode"].tolower()]
+				if(config.joy.leftPeek.tostring() in map) {
+					output += map[config.joy.leftPeek.tostring()]
+				} else {
+					output += "???"
+				}
+			}
 			break
 		case "rightPeek":
 			if(getkey)
 				output += gvLangObj["key"][config.key.rightPeek.tostring()]
-			if(getjoy)
-				output += gvLangObj["joy"][config["joymode"].tolower()][config.joy.rightPeek.tostring()]
+						if(getjoy) {
+				local map = gvLangObj["joy"][config["joymode"].tolower()]
+				if(config.joy.rightPeek.tostring() in map) {
+					output += map[config.joy.rightPeek.tostring()]
+				} else {
+					output += "???"
+				}
+			}
 			break
 		case "downPeek":
 			if(getkey)
 				output += gvLangObj["key"][config.key.downPeek.tostring()]
-			if(getjoy)
-				output += gvLangObj["joy"][config["joymode"].tolower()][config.joy.downPeek.tostring()]
+						if(getjoy) {
+				local map = gvLangObj["joy"][config["joymode"].tolower()]
+				if(config.joy.downPeek.tostring() in map) {
+					output += map[config.joy.downPeek.tostring()]
+				} else {
+					output += "???"
+				}
+			}
 			break
 		case "upPeek":
 			if(getkey)
 				output += gvLangObj["key"][config.key.upPeek.tostring()]
-			if(getjoy)
-				output += gvLangObj["joy"][config["joymode"].tolower()][config.joy.upPeek.tostring()]
+						if(getjoy) {
+				local map = gvLangObj["joy"][config["joymode"].tolower()]
+				if(config.joy.upPeek.tostring() in map) {
+					output += map[config.joy.upPeek.tostring()]
+				} else {
+					output += "???"
+				}
+			}
 			break
 	}
 

--- a/src/menus.nut
+++ b/src/menus.nut
@@ -454,7 +454,7 @@ const menuY = 40
 	{
 		name = function() { return gvLangObj["options-menu"]["joystick2"] },
 		desc = function() { return gvLangObj["options-menu-desc"]["joystick"] },
-		func = function() { menu = meJoybinds2 }
+		func = function() { menu = meJoyBinds2 }
 	},
 	{
 		name = function() {

--- a/src/tux.nut
+++ b/src/tux.nut
@@ -612,7 +612,7 @@
 				}
 
 				//Going into slide
-				if((((!freeDown2 || onPlatform()) && getcon("down", "hold", true, playerNum)) || (getcon("shoot", "hold", true, playerNum) && stats.weapon == "earth")) && anim != "dive" && anim != "slide" && anim != "jumpU" && anim != "jumpT" && anim != "fall" && anim != "hurt" && anim != "wall" && anim != "crawl") {
+				if((((!freeDown2 || onPlatform()) && getcon("down", "hold", true, playerNum))) && anim != "dive" && anim != "slide" && anim != "jumpU" && anim != "jumpT" && anim != "fall" && anim != "hurt" && anim != "wall" && anim != "crawl") {
 					if(placeFree(x + 2, y + 1) && !onPlatform() || hspeed >= 1.5) {
 						anim = "dive"
 						frame = 0.0
@@ -737,7 +737,7 @@
 						if(anim == "crawl") c.y += 8
 					}
 					break
-
+	
 				case "ice":
 					if(getcon("shoot", "press", true, playerNum) && anim != "slide" && anim != "hurt" && stats.energy > 0) {
 						local fx = 6
@@ -769,18 +769,9 @@
 						if(flip == 1 && hspeed > -2) hspeed = -2
 					}
 					break
-
-				case "earth":
-					if(getcon("shoot", "press", true, playerNum) && (anim != "hurt")) {
-						anim = "dive"
-						frame = 0.0
-						playSound(sndSlide, 0)
-						if(flip == 0 && hspeed < 2) hspeed = 2
-						if(flip == 1 && hspeed > -2) hspeed = -2
-					}
-					break
 			}
 
+			
 			if(canMove) switch(stats.subitem) {
 				case "fire":
 					if(getcon("spec1", "press", true, playerNum) && anim != "slide" && anim != "hurt" && stats.energy >= 1) {
@@ -984,6 +975,7 @@
 					break
 			}
 
+			print(stats.subitem)
 			if(canMove) switch(stats.subitem) {
 				case "fire":
 					if(getcon("spec1", "press", true, playerNum) && anim != "slide" && anim != "hurt" && stats.energy > 0) {

--- a/src/tux.nut
+++ b/src/tux.nut
@@ -612,7 +612,7 @@
 				}
 
 				//Going into slide
-				if((((!freeDown2 || onPlatform()) && getcon("down", "hold", true, playerNum))) && anim != "dive" && anim != "slide" && anim != "jumpU" && anim != "jumpT" && anim != "fall" && anim != "hurt" && anim != "wall" && anim != "crawl") {
+				if((((!freeDown2 || onPlatform()) && getcon("down", "hold", true, playerNum)) || (getcon("shoot", "hold", true, playerNum) && stats.weapon == "earth")) && anim != "dive" && anim != "slide" && anim != "jumpU" && anim != "jumpT" && anim != "fall" && anim != "hurt" && anim != "wall" && anim != "crawl") {
 					if(placeFree(x + 2, y + 1) && !onPlatform() || hspeed >= 1.5) {
 						anim = "dive"
 						frame = 0.0
@@ -737,7 +737,7 @@
 						if(anim == "crawl") c.y += 8
 					}
 					break
-	
+
 				case "ice":
 					if(getcon("shoot", "press", true, playerNum) && anim != "slide" && anim != "hurt" && stats.energy > 0) {
 						local fx = 6
@@ -769,9 +769,18 @@
 						if(flip == 1 && hspeed > -2) hspeed = -2
 					}
 					break
+
+				case "earth":
+					if(getcon("shoot", "press", true, playerNum) && (anim != "hurt")) {
+						anim = "dive"
+						frame = 0.0
+						playSound(sndSlide, 0)
+						if(flip == 0 && hspeed < 2) hspeed = 2
+						if(flip == 1 && hspeed > -2) hspeed = -2
+					}
+					break
 			}
 
-			
 			if(canMove) switch(stats.subitem) {
 				case "fire":
 					if(getcon("spec1", "press", true, playerNum) && anim != "slide" && anim != "hurt" && stats.energy >= 1) {
@@ -975,7 +984,6 @@
 					break
 			}
 
-			print(stats.subitem)
 			if(canMove) switch(stats.subitem) {
 				case "fire":
 					if(getcon("spec1", "press", true, playerNum) && anim != "slide" && anim != "hurt" && stats.energy > 0) {


### PR DESCRIPTION
The buttons menu can crash if it tries to get a control name that doesn't exist, which is a valid case if the user uses a controller with more buttons then an xbox/dinput controller (my gamecube controller connected to an adapter has a "button 15" which was causing the game to crash.