### PR TITLE
Fix timer

### DIFF
--- a/src/text.nut
+++ b/src/text.nut
@@ -62,7 +62,7 @@
 	local seconds = (time % 3600).tofloat() / 60.0
 	local minutes = floor(time / 3600)
 
-	local seconds_p1 = ceil(seconds)
+	local seconds_p1 = floor(seconds)
 	local seconds_p2 = (seconds - floor(seconds)) * 1000
 	return format("%02d:%02d.%03d", minutes, seconds_p1, seconds_p2);
 }


### PR DESCRIPTION
The new timer introduced with bcb93bd has a bug that usually leads to it displaying a time one second higher than intended.
Specifically, the timer ticks like this:

- 00:00.000
- 00:01.016
- 00:01.033
- ...
- 00:01.966
- 00:01.983
- 00:01.000
- 00:02.016
- 00:02.033
- ...

This is caused by a partial number of seconds being rounded _up_ instead of _down_ to get the whole part. This PR simply makes it round down.

Current timer:

https://github.com/KelvinShadewing/supertux-advance/assets/103469241/ca1d5d9a-8587-4899-8943-5d0dc2fbcd73

The timer here starts at 1 instead of 0.

This PR:

https://github.com/KelvinShadewing/supertux-advance/assets/103469241/885b8dc1-0152-43da-b37f-17396668fb17

The timer here starts at 0 as it should.